### PR TITLE
Replace the deprecated import in the WindowsApp template.

### DIFF
--- a/visuald/Templates/ProjectItems/WindowsApp/winmain.d
+++ b/visuald/Templates/ProjectItems/WindowsApp/winmain.d
@@ -1,7 +1,7 @@
 module winmain;
 
 import core.runtime;
-import std.c.windows.windows;
+import core.sys.windows.windows;
 
 extern (Windows)
 int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)


### PR DESCRIPTION
This commit replaces the std.c.windows.windows import in the WindowsApp template with core.sys.windows.windows.
