### PR TITLE
Update c2d for latest `std.path`.

### DIFF
--- a/c2d/dmd2d.d
+++ b/c2d/dmd2d.d
@@ -1047,7 +1047,7 @@ class Source
 			string txt = tok.pretext ~ tok.text;
 			undoText(txt);
 			// figure out a unique name
-			ident = structype ~ "_" ~ replace(basename(_file), ".", "_") ~ "_" ~ format("%d", _tokenizer.lineno);
+			ident = structype ~ "_" ~ replace(baseName(_file), ".", "_") ~ "_" ~ format("%d", _tokenizer.lineno);
 			appendText(" " ~ ident ~ " " ~ txt);
 		}
 		else
@@ -2699,7 +2699,7 @@ class Source
 
 			foreach(src; _dmd2d.hdrfiles)
 			{
-				if(basename(src, ".h") == mod)
+				if(baseName(src, ".h") == mod)
 				{
 					mod = moduleName(src) ~ "_h";
 					break;
@@ -2714,7 +2714,7 @@ class Source
 		string oname;
 		if(outputName.length == 0)
 		{
-			string ext = (getExt(_file) == "h" ? "_h.d" : "_c.d");
+			string ext = (extension(_file) == ".h" ? "_h.d" : "_c.d");
 			oname = getName(_file) ~ ext;
 		}
 		else if (find(outputName, "=") >= 0)
@@ -2812,9 +2812,9 @@ struct PatchData
 
 string patchFileText(string file, string text, ref PatchData[] patches)
 {
-	string fname = basename(file);
+	string fname = baseName(file);
 	for(int i = 0; i < patches.length; i++)
-		if (fnmatch(fname, patches[i].file))
+		if (globMatch(fname, patches[i].file))
 			if (patches[i].regexp)
 				text = sub(text, patches[i].match, patches[i].replace, "g");
 			else
@@ -2935,12 +2935,12 @@ class DMD2D
 
 	void addSource(string file)
 	{
-		string base = basename(file);
+		string base = baseName(file);
 		foreach(excl; excludefiles)
 			if(excl == base)
 				return;
 
-		if(getExt(file) == "h")
+		if(extension(file) == ".h")
 			hdrfiles ~= file;
 		else
 			srcfiles ~= file;
@@ -2954,10 +2954,10 @@ class DMD2D
 			mode = SpanMode.depth;
 			file = file[1..$];
 		}
-		string path = dirname(file);
-		string pattern = basename(file);
+		string path = dirName(file);
+		string pattern = baseName(file);
 		foreach (string name; dirEntries(path, mode))
-			if (fnmatch(basename(name), pattern))
+			if (globMatch(baseName(name), pattern))
 				addSource(name);
 	}
 

--- a/c2d/dmdgen.d
+++ b/c2d/dmdgen.d
@@ -2244,8 +2244,8 @@ int firstPathSeparator(string path)
 
 string createImportAll(string filename, bool makefile)
 {
-	string path = dirname(filename);
-	string ext = getExt(filename);
+	string path = dirName(filename);
+	string ext = extension(filename)[1 .. $];
 	string bname = filename[path.length + 1..$-ext.length-1];
 	
 	string txt;
@@ -2288,13 +2288,13 @@ string createImportAll(string filename, bool makefile)
 
 string genOutFilename(string filename, int pass)
 {
-	string path = dirname(filename);
+	string path = dirName(filename);
 	string gendir = pass == 0 ? "dmdgen" : "gen" ~ format("%d", pass);
 	string genpath = replace(path, "dmd", gendir);
 	if(!exists(genpath))
 		mkdirRecurse(genpath);
 
-	string ext = getExt(filename);
+	string ext = extension(filename)[1 .. $];
 	string bname = filename[path.length + 1..$-ext.length-1];
 
 	if(pass == 0)

--- a/c2d/idl2d.d
+++ b/c2d/idl2d.d
@@ -1053,9 +1053,7 @@ version(all)
 			dir = "";
 		else
 			dir ~= "\\";
-		string ext = getExt(fname);
-		if(ext.length > 0)
-			ext = "." ~ ext;
+		string ext = extension(fname);
 		return translatePackageName(dir ~ nname ~ ext);
 	}
 
@@ -2206,7 +2204,7 @@ else
 
 	void addSource(string file)
 	{
-		string base = basename(file);
+		string base = baseName(file);
 		if(excludefiles.contains(base))
 			return;
 		
@@ -2222,10 +2220,10 @@ else
 			mode = SpanMode.depth;
 			file = file[1..$];
 		}
-		string path = dirname(file);
-		string pattern = basename(file);
+		string path = dirName(file);
+		string pattern = baseName(file);
 		foreach (string name; dirEntries(path, mode))
-			if (fnmatch(basename(name), pattern))
+			if (globMatch(baseName(name), pattern))
 				addSource(name);
 	}
 
@@ -2329,8 +2327,8 @@ version(remove_pp) {} else
 		string ins = "  <Folder name=\"port\">\n";
 		string portdir = sdk_d_path ~ "port";
 		foreach (string name; dirEntries(portdir, SpanMode.shallow))
-			if (fnmatch(basename(name), "*.d"))
-				ins ~= "   <File path=\"port\\" ~ basename(name) ~ "\" />\n";
+			if (globMatch(baseName(name), "*.d"))
+				ins ~= "   <File path=\"port\\" ~ baseName(name) ~ "\" />\n";
 		
 		string folder = "port";
 
@@ -2376,7 +2374,7 @@ version(remove_pp) {} else
 	{
 		if(argv.length <= 1)
 		{
-			writeln("usage: ", basename(argv[0]), " {-vsi|-dte|-win|-sdk|-prefix|-verbose|-define} [files...]");
+			writeln("usage: ", baseName(argv[0]), " {-vsi|-dte|-win|-sdk|-prefix|-verbose|-define} [files...]");
 			writeln();
 			writeln(" -vsi=DIR   specify path to Visual Studio Integration SDK");
 			writeln(" -dte=DIR   specify path to additional IDL files from VSI SDK");
@@ -2385,8 +2383,8 @@ version(remove_pp) {} else
 			writeln(" -prefix=P  prefix used for identifiers that are D keywords");
 			writeln(" -verbose   report undefined definitions in preprocessor conditions");
 			writeln();
-			writeln("Example: ", basename(argv[0]), ` test.idl`);
-			writeln("         ", basename(argv[0]), ` -win="%WindowsSdkDir%\Include" -vsi="%VSSDK110Install%" -sdk=sdk`);
+			writeln("Example: ", baseName(argv[0]), ` test.idl`);
+			writeln("         ", baseName(argv[0]), ` -win="%WindowsSdkDir%\Include" -vsi="%VSSDK110Install%" -sdk=sdk`);
 			return -1;
 		}
 

--- a/c2d/j2d.d
+++ b/c2d/j2d.d
@@ -682,7 +682,7 @@ class j2d
 
 	void addSource(string file)
 	{
-		string base = basename(file);
+		string base = baseName(file);
 		foreach(excl; excludefiles)
 			if(excl == base)
 				return;
@@ -698,10 +698,10 @@ class j2d
 			mode = SpanMode.depth;
 			file = file[1..$];
 		}
-		string path = dirname(file);
-		string pattern = basename(file);
+		string path = dirName(file);
+		string pattern = baseName(file);
 		foreach (string name; dirEntries(path, mode))
-			if (fnmatch(basename(name), pattern))
+			if (globMatch(baseName(name), pattern))
 				addSource(name);
 	}
 
@@ -735,7 +735,7 @@ class j2d
 				txt ~= (isInterface ? "interface" : "class") ~ " " ~ imp[pos + 1 .. $] ~ "\n";
 				txt ~= "{\n}\n";
 
-				string path = dirname(d_file);
+				string path = dirName(d_file);
 				if(!exists(path))
 					std.file.mkdirRecurse(path);
 				std.file.write(d_file, txt);

--- a/c2d/patchast.d
+++ b/c2d/patchast.d
@@ -1613,7 +1613,7 @@ int firstPathSeparator(string path)
 version(none)
 string createImportAll(string filename, bool makefile)
 {
-	string path = dirname(filename);
+	string path = dirName(filename);
 	string ext = getExt(filename);
 	string bname = filename[path.length + 1..$-ext.length-1];
 	
@@ -1657,7 +1657,7 @@ string createImportAll(string filename, bool makefile)
 
 string genOutFilename(string filename, int pass)
 {
-	string path = dirname(filename);
+	string path = dirName(filename);
 	string gendir = pass == 0 ? "dmdgen" : "gen" ~ format("%d", pass);
 	string genpath = replace(path, "dmd", gendir);
 	if(!exists(genpath))

--- a/c2d/pp4d.d
+++ b/c2d/pp4d.d
@@ -1078,7 +1078,7 @@ class pp4d
 	//////////////////////////////////////////////////////////////
 	void addSource(string file)
 	{
-		string base = basename(file);
+		string base = baseName(file);
 		if(excludefiles.contains(base))
 			return;
 		
@@ -1094,10 +1094,10 @@ class pp4d
 			mode = SpanMode.depth;
 			file = file[1..$];
 		}
-		string path = dirname(file);
-		string pattern = basename(file);
+		string path = dirName(file);
+		string pattern = baseName(file);
 		foreach (string name; dirEntries(path, mode))
-			if (fnmatch(basename(name), pattern))
+			if (globMatch(baseName(name), pattern))
 				addSource(name);
 	}
 


### PR DESCRIPTION
Remove usage of deprecated and removed functions:
- replace `getExt` with `extension` and correct
- replace `basename` with `baseName`
- replace `dirname` with `dirName`
- replace `fnmatch` with `globMatch`
