### PR TITLE
Visual D 0.3.38rc1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -621,3 +621,8 @@ unreleased Version 0.3.38
   * disguise functionality of pipedmd.exe and filemonitor.dll to let it pass 
     most anti-virus checks
   * added option to select the C runtime library when compiling for x64
+
+  * completion on import statements no longer showed folder icons
+  * completion on selective import now lists identifiers from imported module
+  * dparser: fixed completion for symbols without description
+  * dparser: added support for multi line completions (including override completion)

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Copyright (c) 2010-2013 by Rainer Schuetze, All Rights Reserved
 Visual D aims at providing seamless integration of the D programming language
 into Visual Studio. 
 
-For installer download, more documentation, build instructions, forum and
-issue reporting, please visit the http://www.dsource.org/projects/visuald.
+For installer download, more documentation and build instructions, please visit http://rainers.github.io/visuald/visuald/StartPage.html.
+Use forum http://forum.dlang.org/group/digitalmars.D.ide for questions and the D bug tracker https://d.puremagic.com/issues/ to report issues.
+
 
 Major Features
 ---------------
@@ -59,6 +60,7 @@ Major Features
   - VS 2008
   - VS 2010
   - VS 2012
+  - VS 2013
   Unfortunately, Express versions of Visual Studio do not support this 
   kind of extensions. Use the Visual Studio Shell instead:
   - VS 2008 Shell: http://www.microsoft.com/en-us/download/details.aspx?id=9771
@@ -91,14 +93,15 @@ Building Visual D
 -----------------
 In a nutshell:
 
-- adjust environment variables in the root Makefile
-- run "nmake sdk"
+- install the Visual Studio SDK
 - start Visual Studio and load solution visuald_vs9.sln (VS 2008) or
   visuald_vs10.sln (VS 2010)
+- build project "build"
 - build project "VisualD"
 
 For more information, visit
-	http://www.dsource.org/projects/visuald/wiki/Build_from_source
+http://rainers.github.io/visuald/visuald/BuildFromSource.html
+
 
 Installation
 ------------
@@ -130,9 +133,9 @@ More Information
 ----------------
 For more information on installation, a quick tour of Visual D with some
 screen shots and feedback, please visit the project home for Visual D at 
-[http://www.dsource.org/projects/visuald](http://www.dsource.org/projects/visuald).
+[http://rainers.github.io/visuald/visuald/StartPage.html](http://rainers.github.io/visuald/visuald/StartPage.html).
 
-There's also a forum, where you can leave your comments and suggestions.
+There's a forum dedicated to IDE discussions (http://forum.dlang.org/group/digitalmars.D.ide), where you can leave your comments and suggestions.
 Bug reports can be filed to the [D bugzilla database](http://d.puremagic.com/issues/enter_bug.cgi?product=D) 
 for Component VisualD.
 

--- a/TODO
+++ b/TODO
@@ -38,8 +38,7 @@ Project:
 - single file compilation for file configuration
 - custom command: quotes in dependencies not supported
 - VS2013: property pages don't follow resize
-- custom command: writes build batch to souce folder
-- does not work with VS2013 git integration
+- custom command: writes build batch to source folder
 
 Language service:
 -----------------

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 #define VERSION_MAJOR      0
 #define VERSION_MINOR      3
 #define VERSION_REVISION   38
-#define VERSION_BETA       -beta
-#define VERSION_BUILD      4
+#define VERSION_BETA       -rc
+#define VERSION_BUILD      1

--- a/doc/Features.dd
+++ b/doc/Features.dd
@@ -46,11 +46,11 @@ Ddoc
   )
   $(LI Supported Visual Studio versions
    $(UL
-    $(LI VS.NET 2003 (some limitations apply))
     $(LI VS 2005)
     $(LI VS 2008)
     $(LI VS 2010)
     $(LI VS 2012)
+    $(LI VS 2013)
    )
    Unfortunately, Express versions of Visual Studio do not support this kind of extensions. 
    But you can use the (integrated) Visual Studio Shell (download 

--- a/doc/KnownIssues.dd
+++ b/doc/KnownIssues.dd
@@ -19,20 +19,6 @@ the debug information by cv2pdb. This is msobj80.dll for VS2008 and msobj100.dll
 be extracted from a standard installation, the Visual C Express edition or the Windows SDK. You might
 also find it installed by other Microsoft products.)
 
-$(H2 Library search path not passed to linker)
-
-$(P Even though Visual D allows to set a library search path, this does not work with 
-the default installation of DMD. Optlink, the linker used by DMD, only accepts the path 
-in the LIB environment variable (this is set by Visual D), but dmd overwrites it with 
-the settings in its configuration file sc.ini.)
-
-$(P You should change the LIB setting in <dmd-installation-path>\windows\bin\sc.ini to this:
-$(PRE
-  LIB="%@P%\..\lib";\dm\lib;%DMD_LIB% 
-)
-to pass through the value set by Visual D. Since version 0.3.14, DMD_LIB is used instead of LIB to avoid conflicts
-with the environment variable LIB being used by other compilers.)
-
 $(H2 No parameter tool tips when running alongside Visual Assist)
 
 $(P Visual Assist is an extension to Visual Studio that adds a lot of editing functionality 

--- a/vdc/abothe/VDServer.cs
+++ b/vdc/abothe/VDServer.cs
@@ -114,9 +114,11 @@ namespace DParserCOMServer
 			else if (Node is DModule)
 				type = "MOD";
 
-			string desc = Node.Description.Trim();
-			string proto = VDServerCompletionDataGenerator.GeneratePrototype(Node);
+			string desc = Node.Description;
+            if(!string.IsNullOrEmpty(desc))
+                desc = desc.Trim();
 
+			string proto = VDServerCompletionDataGenerator.GeneratePrototype(Node);
 			if (!string.IsNullOrEmpty(proto) && !string.IsNullOrEmpty(desc))
 				proto = proto + "\n\n";
 			desc = proto + desc;
@@ -143,14 +145,19 @@ namespace DParserCOMServer
 
 		public void AddCodeGeneratingNodeItem(INode node, string codeToGenerate)
 		{
-			addExpansion(codeToGenerate, "OVR", codeToGenerate);
+			addExpansion(node.Name + "|" + codeToGenerate, "OVR", codeToGenerate);
+		}
+
+		public void AddIconItem(string iconName, string text, string description)
+		{
+			addExpansion(iconName + "|" + text, "ICN", description);
 		}
 
 		void addExpansion(string name, string type, string desc)
 		{
 			if(!string.IsNullOrEmpty(name))
 				if(name.StartsWith(prefix))
-					expansions += name + ":" + type + ":" + desc.Replace("\r\n", "\a").Replace('\n', '\a')  + "\n";
+					expansions += name.Replace("\r\n", "\a").Replace('\n', '\a') + ":" + type + ":" + desc.Replace("\r\n", "\a").Replace('\n', '\a') + "\n";
 		}
 
 		// generate prototype

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -274,6 +274,8 @@ class ProjectOptions
 	void setX64(bool x64)
 	{
 		isX86_64 = x64;
+		if(!release && cRuntime == CRuntime.StaticRelease)
+			cRuntime = CRuntime.StaticDebug;
 	}
 
 	string objectFileExtension() { return compiler != Compiler.GDC ? "obj" : "o"; }

--- a/visuald/dimagelist.d
+++ b/visuald/dimagelist.d
@@ -110,4 +110,5 @@ enum CSIMG_JINTERFACE     = 180;
 enum CSIMG_STOP           = 186; // series of single bitmaps follow
 
 enum CSIMG_DMODULE        = 194;
+enum CSIMG_DFOLDER        = 201;
 enum CSIMG_KEYWORD        = 206;

--- a/visuald/dlangsvc.d
+++ b/visuald/dlangsvc.d
@@ -3239,7 +3239,11 @@ else
 		auto lntokIt2 = lntokIt;
 		while(tok != "import" && (tok == "," || tok == "=" || tok == ":" || tok == "." || dLex.isIdentifier(tok))
 			  && lntokIt.retreatOverComments())
+		{
+			if(tok == ":")
+				return null; // no import handling on selective import identifier
 			tok = lntokIt.getText();
+		}
 
 		if(tok != "import")
 			return null;

--- a/visuald/dproject.d
+++ b/visuald/dproject.d
@@ -1188,6 +1188,12 @@ class Project : CVsHierarchy,
 			case cmdidRebuildOnlyProject:
 			case cmdidCleanOnlyProject:
 				return GetProjectNode().QueryStatus(pguidCmdGroup, cCmds, prgCmds, pCmdText);
+			case ECMD_SHOWALLFILES:
+				debug
+				{
+					Cmd.cmdf = OLECMDF_SUPPORTED | OLECMDF_ENABLED;
+					return hr;
+				}
 			default:
 				break;
 			}

--- a/visuald/hierarchy.d
+++ b/visuald/hierarchy.d
@@ -785,6 +785,7 @@ class CFolderNode : CHierContainer
 				case cmdidExploreFolderInWindows:
 					hr = OnExploreFolderInWindows();
 					break;
+				case ECMD_SHOWALLFILES:
 				default:
 					break;
 			}

--- a/visuald/propertypage.d
+++ b/visuald/propertypage.d
@@ -1187,7 +1187,7 @@ class DmdLinkerPropertyPage : ProjectPropertyPage
 			[ "Minimum", "Symbols By Address", "Standard", "Full", "With cross references" ], false));
 		AddControl("", mImplib = new CheckBox(mCanvas, "Create import library"));
 		AddControl("", mUseStdLibPath = new CheckBox(mCanvas, "Use global and standard library search paths"));
-		AddControl("C Runtime", mCRuntime = new ComboBox(mCanvas, [ "None", "Static Release (LIBCMT)", "Static Debug (LIBCMTD)", "Dynamic Release (MSCVRT)", "Dynamic Release (MSCVRTD)" ], false));
+		AddControl("C Runtime", mCRuntime = new ComboBox(mCanvas, [ "None", "Static Release (LIBCMT)", "Static Debug (LIBCMTD)", "Dynamic Release (MSCVRT)", "Dynamic Debug (MSCVRTD)" ], false));
 	}
 
 	void EnableControls()

--- a/visuald/visuald.visualdproj
+++ b/visuald/visuald.visualdproj
@@ -89,6 +89,7 @@
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).dll</exefile>
   <useStdLibPath>1</useStdLibPath>
+  <cRuntime>1</cRuntime>
   <additionalOptions />
   <preBuildCommand />
   <postBuildCommand />
@@ -183,6 +184,7 @@
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).dll</exefile>
   <useStdLibPath>1</useStdLibPath>
+  <cRuntime>1</cRuntime>
   <additionalOptions />
   <preBuildCommand />
   <postBuildCommand />
@@ -277,6 +279,7 @@
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).exe</exefile>
   <useStdLibPath>1</useStdLibPath>
+  <cRuntime>1</cRuntime>
   <additionalOptions>-gx</additionalOptions>
   <preBuildCommand />
   <postBuildCommand />
@@ -371,6 +374,7 @@
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).dll</exefile>
   <useStdLibPath>1</useStdLibPath>
+  <cRuntime>1</cRuntime>
   <additionalOptions>-debuglib=phobos,druntime</additionalOptions>
   <preBuildCommand />
   <postBuildCommand />
@@ -465,6 +469,7 @@
   <resfile />
   <exefile>$(OutDir)\..\Debug\$(ProjectName).dll</exefile>
   <useStdLibPath>1</useStdLibPath>
+  <cRuntime>1</cRuntime>
   <additionalOptions>-debuglib=phobos_d,druntime_d -m32ms -L/DLL -L/FORCE:UNRESOLVED</additionalOptions>
   <preBuildCommand />
   <postBuildCommand />


### PR DESCRIPTION
- completion on selective import now lists identifiers from imported module
- dparser: fixed completion for symbols without description
- dparser: added support for multi line completions (including override completion)
- remove references to dsource from doc

Sorry for the huge diff, but git doesn't want it otherwise.
