### PR TITLE
Don't rebuild if terget file has same time

### DIFF
--- a/visuald/config.d
+++ b/visuald/config.d
@@ -2298,7 +2298,7 @@ class Config :	DisposingComObject,
 		long targettm = getOldestFileTime( [ outfile ], oldestFile );
 		long sourcetm = getNewestFileTime(deps, newestFile);
 
-		if(targettm > sourcetm)
+		if(targettm >= sourcetm)
 			return true;
 		if(preason)
 			*preason = newestFile ~ " is newer";


### PR DESCRIPTION
A common usecase is a file copied into the target directory.
