### PR TITLE
Don't pop up JitDebugger window if "COM Server for DParser" crashes

### DIFF
--- a/vdc/abothe/comserver/DParserCOMServer.cs
+++ b/vdc/abothe/comserver/DParserCOMServer.cs
@@ -295,8 +295,12 @@ namespace DParserCOMServer
 		/// </summary>
 		static void Main(string[] args)
 		{
+			SetErrorMode(3); //don't show JitDebugger on crash
 			// Run the out-of-process COM server
 			ExeCOMServer.Instance.Run();
 		}
+
+		[DllImport("Kernel32.dll")]
+		public static extern uint SetErrorMode(uint mode);
 	}
 }

--- a/vdc/abothe/comserver/DParserCOMServer.csproj
+++ b/vdc/abothe/comserver/DParserCOMServer.csproj
@@ -71,7 +71,4 @@
       <Name>DParser2</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
"COM Server for DParser" crashes a lot with stack overflow on some projects (like DLangUI).
Every time it happens Just-in-Time Debugging window appears offering to close or debug it, which is very annoying.
This small change allows DParserCOMServer.exe crash silently, without any annoying windows.

Also, app.config file was missing, so I removed reference to it from the project.
