### PR TITLE
Failed to handle the resource file on Win7+VS2013

### DIFF
--- a/visuald/config.d
+++ b/visuald/config.d
@@ -2695,7 +2695,7 @@ class Config :	DisposingComObject,
 			string ext = toLower(extension(fname));
 			if(isIn(ext, ".d", ".ddoc", ".def", ".lib", ".obj", ".o", ".res"))
 				tool = "DMD";
-			else if(ext == "rc")
+			else if(ext == ".rc")
 				tool = kToolResourceCompiler;
 			else if(isIn(ext, ".c", ".cpp", ".cxx", ".cc"))
 				tool = kToolCpp;
@@ -2714,7 +2714,7 @@ class Config :	DisposingComObject,
 				tool = "DMDsingle";
 			else if(isIn(ext, ".d", ".ddoc", ".def", ".lib", ".obj", ".o", ".res"))
 				tool = "DMD";
-			else if(ext == "rc")
+			else if(ext == ".rc")
 				tool = kToolResourceCompiler;
 			else if(isIn(ext, ".c", ".cpp", ".cxx", ".cc"))
 				tool = kToolCpp;

--- a/visuald/dpackage.d
+++ b/visuald/dpackage.d
@@ -1502,13 +1502,15 @@ class GlobalOptions
 			// $(WindowsSdkDir)\bin needed for rc.exe
 			// $(VCInstallDir)\bin needed to compile C + link.exe + DLLs
 			// $(VSINSTALLDIR)\Common7\IDE needed for some VS versions for cv2pdb
-			DMD.ExeSearchPath = r"$(VCInstallDir)\bin;$(VSINSTALLDIR)\Common7\IDE;$(WindowsSdkDir)\bin;$(DMDInstallDir)windows\bin";
-			DMD.ExeSearchPath64     = DMD.ExeSearchPath;
+            string windowsSdkX86Bin = r"$(WindowsSdkDir)bin\x86";
+            string windowsSdkX64Bin = r"$(WindowsSdkDir)bin\x64";
+			DMD.ExeSearchPath = r"$(VCInstallDir)\bin;$(VSINSTALLDIR)\Common7\IDE;" ~ windowsSdkX86Bin ~ r";$(DMDInstallDir)windows\bin";
+			DMD.ExeSearchPath64     = r"$(VCInstallDir)\bin;$(VSINSTALLDIR)\Common7\IDE;" ~ windowsSdkX64Bin ~ r";$(DMDInstallDir)windows\bin";
 			DMD.ExeSearchPath32coff = DMD.ExeSearchPath;
-			GDC.ExeSearchPath       = r"$(GDCInstallDir)\bin;$(VSINSTALLDIR)\Common7\IDE;$(WindowsSdkDir)\bin";
+			GDC.ExeSearchPath       = r"$(GDCInstallDir)\bin;$(VSINSTALLDIR)\Common7\IDE;" ~ windowsSdkX86Bin;
 			GDC.ExeSearchPath64     = GDC.ExeSearchPath;
-			LDC.ExeSearchPath       = r"$(LDCInstallDir)\bin;$(VCInstallDir)\bin;$(VSINSTALLDIR)\Common7\IDE;$(WindowsSdkDir)\bin";
-			LDC.ExeSearchPath64     = r"$(LDCInstallDir)\bin;$(VCInstallDir)\bin\amd64;$(WindowsSdkDir)\bin";
+			LDC.ExeSearchPath       = r"$(LDCInstallDir)\bin;$(VCInstallDir)\bin;$(VSINSTALLDIR)\Common7\IDE;" ~ windowsSdkX86Bin;
+			LDC.ExeSearchPath64     = r"$(LDCInstallDir)\bin;$(VCInstallDir)\bin\amd64;" ~ windowsSdkX64Bin;
 
 			DMD.LibSearchPath64     = getDefaultLibPathCOFF64();
 			LDC.LibSearchPath64     = DMD.LibSearchPath64;


### PR DESCRIPTION
Maybe the path for rc.exe is different on the other OS like Windows XP. I just tested this path on Win7 x64.
