### PR TITLE
Version 0.44.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -806,7 +806,7 @@ Version history
     - search pane did not save its last state, only when switching between file and symbol search
     - dustmite: pattern passed to "find" must always use quotes
 
-unreleased Version 0.44
+2017-03-12 Version 0.44
 
   * installation
     - added preliminary support for VS 2017 RC
@@ -852,3 +852,7 @@ unreleased Version 0.44
       - without any match, still keep the completion box open with recent items
       - less flashing when updating the results
       - code snippets now added to possible expansions
+
+2017-03-13 Version 0.44.1
+
+  * bugzilla 17252: Fixed bad character inserted into the executable search path default

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 #define VERSION_MAJOR      0
 #define VERSION_MINOR      44
-#define VERSION_REVISION   0
+#define VERSION_REVISION   1
 #define VERSION_BETA       
 #define VERSION_BUILD      0

--- a/doc/VersionHistory.dd
+++ b/doc/VersionHistory.dd
@@ -1,5 +1,10 @@
 Ddoc
 
+$(H2 2017-03-12 Version 0.44.1)
+ $(UL
+  $(LI bugzilla 17252: Fixed bad character inserted into the executable search path default)
+ )
+
 $(H2 2017-03-12 Version 0.44)
  $(UL
   $(LI installation

--- a/doc/visuald.ddoc
+++ b/doc/visuald.ddoc
@@ -1,4 +1,4 @@
-VERSION = 0.44.0
+VERSION = 0.44.1
 ROOT_DIR = http://www.dlang.org/
 ROOT = http://www.dlang.org
 BODYCLASS = visuald

--- a/visuald/dpackage.d
+++ b/visuald/dpackage.d
@@ -1573,7 +1573,7 @@ class GlobalOptions
 			string sdkBinDir = "$(WindowsSdkDir)bin";
 			if (std.file.exists(WindowsSdkDir ~ "bin\\x86\\rc.exe")) // path changed with Windows 8 SDK
 				sdkBinDir ~= "\\x86";
-			DMD.ExeSearchPath       = getVCDir("bin", false) ~ r";$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir ~ ";$(DMDInstallDir)windows\bin";
+			DMD.ExeSearchPath       = getVCDir("bin", false) ~ r";$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir ~ ";$(DMDInstallDir)windows\\bin";
 			DMD.ExeSearchPath64     = DMD.ExeSearchPath;
 			DMD.ExeSearchPath32coff = DMD.ExeSearchPath;
 			GDC.ExeSearchPath       = r"$(GDCInstallDir)bin;$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir;


### PR DESCRIPTION
bugzilla 17252: Fixed bad character inserted into the executable search path default