### PR TITLE
Changes for 0.45-rc1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -867,26 +867,32 @@ Version history
 
 unreleased Version 0.45.0
 
-  * fixed Compile and Run/Debug if building through MS-COFF and not having VS selected in sc.ini
-  * mago: fixed memory leaks that could also prohibit compilation due to PDB file still open
-  * mago: add debugger options page to allow hiding internal locals and static members
-  * cv2pdb: added support for AA display in mago
-  * DParser: added support for function attributes @nogc and scope, align(expression)
-  * added task list support for files loaded into the editor
-  * read default DMD installation path from Visual D or DMD registry key, if not available in 
-    VS registry hive
-  * cpp2d: add missing default to switch(), ensure space between identifiers, fix module 
-    name for translated C-files
-  * new project option "Add import paths of project dependencies"
-  * use generic file system tracking instead of compiler switch -deps=
-  * fixed tracker.exe not found in VS2015 and VS2017
-  * /MAPINFO: remove ancient options no longer supported by the MS linker
-  * separated compile and link into two batches so compile skipped if only link inputs changed
-  * fix crash when editing dub.json when part of a project
-  * UCRT version detection: ignore directories that do not start with a digit (e.g. from DDK)
-  * dependency monitoring: added option to specify files/folders to exclude from dependency check
-  * mago: can now show registers in expressions
-  * mago: show static members and base class with different icons
-  * DParser: cache semantic results until next edit
-  * DParser: break endless loop due to unresolved selective import
-  * bugzilla Issue 17384: fix default executable search path for LDC/x64 under VS2017
+  * mago debugger:
+    - fixed memory leaks that could also prohibit compilation due to PDB file still open
+    - add debugger options page to allow hiding internal locals and static members
+    - can now show registers in expressions
+    - show static members and base class with different icons
+    - fixed x64 debugger failing to start
+    - cv2pdb: added support for AA display in mago
+  * build system
+    - use generic file system tracking instead of compiler switch -deps=
+    - fixed tracker.exe not found in VS2015 and VS2017
+    - new project option "Add import paths of project dependencies"
+    - fixed Compile and Run/Debug if building through MS-COFF and not having VS selected in sc.ini
+    - /MAPINFO: remove ancient options no longer supported by the MS linker
+    - separated compile and link into two batches so compile skipped if only link inputs changed
+    - dependency monitoring: added option to specify files/folders to exclude from dependency check
+  * editor
+    - fix crash when editing dub.json when part of a project
+    - added task list support for files loaded into the editor
+  * installation
+    - read default DMD installation path from Visual D or DMD registry key, if not available in VS registry hive
+    - UCRT version detection: ignore directories that do not start with a digit (e.g. from DDK)
+    - bugzilla Issue 17384: fix default executable search path for LDC/x64 under VS2017
+  * cpp2d: add missing default to switch(), ensure space between identifiers, fix module name for translated C-files
+  * DParser seantic engine:
+    - added support for function attributes @nogc and scope, align(expression)
+    - cache semantic results until next edit
+    - break endless loop due to unresolved selective import
+    - fix for no expansions for symbols from public import in imported module
+    - try dparser as fallback if goto definition on import fails

--- a/CHANGES
+++ b/CHANGES
@@ -875,6 +875,8 @@ unreleased Version 0.45.0
   * added task list support for files loaded into the editor
   * read default DMD installation path from Visual D or DMD registry key, if not available in 
     VS registry hive
+  * cpp2d: add missing default to switch(), ensure space between identifiers, fix module 
+    name for translated C-files
   * new project option "Add import paths of project dependencies"
   * use generic file system tracking instead of compiler switch -deps=
   * fixed tracker.exe not found in VS2015 and VS2017
@@ -886,3 +888,5 @@ unreleased Version 0.45.0
   * mago: can now show registers in expressions
   * mago: show static members and base class with different icons
   * DParser: cache semantic results until next edit
+  * DParser: break endless loop due to unresolved selective import
+  * bugzilla Issue 17384: fix default executable search path for LDC/x64 under VS2017

--- a/TODO
+++ b/TODO
@@ -163,10 +163,10 @@ Mago:
 - string/wstring shown as char/wchar[], but with correct string representation
 + AA indexing
 + AA preview/expand
-- new AA implementation
++ new AA implementation
 - Array preview
 - delegate value/type
-- struct preview
++ struct preview
 + verboser output when loading/unloading DLLs
 - attach to process
 - hardware breakpoints
@@ -226,3 +226,10 @@ Unsorted
 - does not rebuild lib if c-file recompiled
 
 - cannot remove deleted project from solution
+
+- dparser: doesn't support qualified name in catch(fqn)
+
+0.45.0
+======
+- exception on vdextensions: The Visual Studio component cache is out of date 
+

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 #define VERSION_MAJOR      0
 #define VERSION_MINOR      45
 #define VERSION_REVISION   0
-#define VERSION_BETA       -beta
+#define VERSION_BETA       -rc
 #define VERSION_BUILD      1

--- a/visuald/dpackage.d
+++ b/visuald/dpackage.d
@@ -1647,7 +1647,7 @@ class GlobalOptions
 			GDC.ExeSearchPath       = r"$(GDCInstallDir)bin;$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir;
 			GDC.ExeSearchPath64     = GDC.ExeSearchPath;
 			LDC.ExeSearchPath       = r"$(LDCInstallDir)bin;" ~ getVCDir("bin", false) ~ r";$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir;
-			LDC.ExeSearchPath64     = r"$(LDCInstallDir)bin;" ~ getVCDir("bin", true)  ~ r";" ~ sdkBinDir;
+			LDC.ExeSearchPath64     = r"$(LDCInstallDir)bin;" ~ getVCDir("bin", true)  ~ r";$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir;
 
 			DMD.LibSearchPath64     = getDefaultLibPathCOFF64();
 			LDC.LibSearchPath64     = DMD.LibSearchPath64;

--- a/visuald/viewfilter.d
+++ b/visuald/viewfilter.d
@@ -1351,7 +1351,8 @@ else
 					hr = OpenFileInSolution(imp, -1, 0, file, false);
 				}
 			}
-			return hr;
+			if (hr == S_OK)
+				return hr;
 		}
 
 		if(Package.GetGlobalOptions().semanticGotoDef)


### PR DESCRIPTION
- fix for no expansions for symbols from public import in imported module
- try dparser as fallback if goto definition on import fails
- bugzilla Issue 17384: fix default executable search path for LDC/x64 under VS2017