### PR TITLE
changes for Visual D 0.46.0-beta1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -921,24 +921,26 @@ unreleased Version 0.46.0
   * cv2pdb
     - now also search VS2017 registry entries to find mspdb140.dll
     - fix working with the VS2017 update 15.3.1
-  * add workaround for broken TLS when linking with link.exe from VS2017 update 15.3.1
   * improve handling of non-ASCII installation paths:
     - use unicode aware version of NSIS, register through wide string API of rundll32
     - parse sc.ini with current code page
     - pipedmd: pass wide string command line to sub process
     - convert MS linker response file to UTF16
-  * build single object file to intermediate directory rather than output folder
-  * intermediate executable for cv2pdb now written to intermediate directory
-  * custom build batch files now written to intermediate directory
+  * build system
+    - add workaround for broken TLS when linking with link.exe from VS2017 update 15.3.1
+    - build single object file to intermediate directory rather than output folder
+    - intermediate executable for cv2pdb now written to intermediate directory
+    - custom build batch files now written to intermediate directory
+    - use "if %errorlevel% neq 0" instead of "if errorlevel 1" in batches to capture crashes, too
+    - fix default executable search path for LDC assuming a 64-bit compiler executable (avoids 
+      linker error -1073741701)
+    - added *.tlog to default files to clean
+    - add import library to project outputs if "create import library" enabled
+    - added linker options to configure map file, import library and PDB file
+    - LDC: add option to link against debug runtime library
+    - LDC: no longer trIES to run cv2pdb
   * dparser:
     - when building with LDC, use import path from its config file instead of DMDs' sc.ini
     - parse "static foreach" (but no semantic analysis)
-  * use "if %errorlevel% neq 0" instead of "if errorlevel 1" in batches to capture crashes, too
-  * fix default executable search path for LDC assuming a 64-bit compiler executable (avoids 
-    linker error -1073741701)
-  * added *.tlog to default files to clean
   * fixed spurious freeze in precise GC (mostly during startup)
-  * add import library to project outputs if "create import library" enabled
-  * added linker options to configure map file, import library and PDB file
   * indentation of lambdas as parameter arguments now aligns statements on tab stops
-  * LDC: add option to link against debug runtime library

--- a/CHANGES
+++ b/CHANGES
@@ -927,3 +927,5 @@ unreleased Version 0.46.0
     - parse sc.ini with current code page
     - pipedmd: pass wide string command line to sub process
     - convert MS linker response file to UTF16
+  * build single object file to intermediate directory rather than output folder
+  * custom build batch files now written to intermediate directory

--- a/CHANGES
+++ b/CHANGES
@@ -929,3 +929,5 @@ unreleased Version 0.46.0
     - convert MS linker response file to UTF16
   * build single object file to intermediate directory rather than output folder
   * custom build batch files now written to intermediate directory
+  * dparser:
+    - when building with LDC, use import path from its config file instead of DMDs' sc.ini

--- a/CHANGES
+++ b/CHANGES
@@ -928,6 +928,11 @@ unreleased Version 0.46.0
     - pipedmd: pass wide string command line to sub process
     - convert MS linker response file to UTF16
   * build single object file to intermediate directory rather than output folder
+  * intermediate executable for cv2pdb now written to intermediate directory
   * custom build batch files now written to intermediate directory
   * dparser:
     - when building with LDC, use import path from its config file instead of DMDs' sc.ini
+  * use "if %errorlevel% neq 0" instead of "if errorlevel 1" in batches to capture crashes, too
+  * fix default executable search path for LDC assuming a 64-bit compiler executable (avoids 
+    linker error -1073741701)
+  * added *.tlog to default files to clean

--- a/CHANGES
+++ b/CHANGES
@@ -916,10 +916,14 @@ Version history
       better display for enum and aliases
     - fixed completion or tooltips sometimes not working before modifying source code
 
-2017-09-03 Version 0.45.2
+unreleased Version 0.46.0
 
   * cv2pdb
     - now also search VS2017 registry entries to find mspdb140.dll
     - fix working with the VS2017 update 15.3.1
   * add workaround for broken TLS when linking with link.exe from VS2017 update 15.3.1
-
+  * improve handling of non-ASCII installation paths:
+    - use unicode aware version of NSIS, register through wide string API of rundll32
+    - parse sc.ini with current code page
+    - pipedmd: pass wide string command line to sub process
+    - convert MS linker response file to UTF16

--- a/CHANGES
+++ b/CHANGES
@@ -939,3 +939,4 @@ unreleased Version 0.46.0
   * fixed spurious freeze in precise GC (mostly during startup)
   * add import library to project outputs if "create import library" enabled
   * added linker options to configure map file, import library and PDB file
+  * parse "static foreach" (but no semantic analysis)

--- a/CHANGES
+++ b/CHANGES
@@ -932,6 +932,7 @@ unreleased Version 0.46.0
   * custom build batch files now written to intermediate directory
   * dparser:
     - when building with LDC, use import path from its config file instead of DMDs' sc.ini
+    - parse "static foreach" (but no semantic analysis)
   * use "if %errorlevel% neq 0" instead of "if errorlevel 1" in batches to capture crashes, too
   * fix default executable search path for LDC assuming a 64-bit compiler executable (avoids 
     linker error -1073741701)
@@ -939,4 +940,5 @@ unreleased Version 0.46.0
   * fixed spurious freeze in precise GC (mostly during startup)
   * add import library to project outputs if "create import library" enabled
   * added linker options to configure map file, import library and PDB file
-  * parse "static foreach" (but no semantic analysis)
+  * indentation of lambdas as parameter arguments now aligns statements on tab stops
+  * LDC: add option to link against debug runtime library

--- a/CHANGES
+++ b/CHANGES
@@ -936,3 +936,6 @@ unreleased Version 0.46.0
   * fix default executable search path for LDC assuming a 64-bit compiler executable (avoids 
     linker error -1073741701)
   * added *.tlog to default files to clean
+  * fixed spurious freeze in precise GC (mostly during startup)
+  * add import library to project outputs if "create import library" enabled
+  * added linker options to configure map file, import library and PDB file

--- a/CHANGES
+++ b/CHANGES
@@ -915,3 +915,11 @@ Version history
     - improved tooltips: show full qualified name, show initializer for constants,
       better display for enum and aliases
     - fixed completion or tooltips sometimes not working before modifying source code
+
+2017-09-03 Version 0.45.2
+
+  * cv2pdb
+    - now also search VS2017 registry entries to find mspdb140.dll
+    - fix working with the VS2017 update 15.3.1
+  * add workaround for broken TLS when linking with link.exe from VS2017 update 15.3.1
+

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 #define VERSION_MAJOR      0
-#define VERSION_MINOR      45
-#define VERSION_REVISION   2
+#define VERSION_MINOR      46
+#define VERSION_REVISION   0
 #define VERSION_BETA       -beta
 #define VERSION_BUILD      1

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 #define VERSION_MAJOR      0
 #define VERSION_MINOR      45
-#define VERSION_REVISION   1
-#define VERSION_BETA       
-#define VERSION_BUILD      0
+#define VERSION_REVISION   2
+#define VERSION_BETA       -beta
+#define VERSION_BUILD      1

--- a/build/build.visualdproj
+++ b/build/build.visualdproj
@@ -312,6 +312,13 @@ echo. &gt;&quot;$(TargetDir)\build.dep&quot;</postBuildCommand>
   <filesToClean>*.obj;*.cmd;*.build;*.json;*.dep</filesToClean>
  </Config>
  <Folder name="build">
+  <File path="..\tools\mb2utf16.d" customcmd="dmd -map $(OutDir)\$(InputName).map -of$(OutDir)\$(InputName).exe $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" perConfig="true" outfile="$(OutDir)\$(InputName).exe">
+   <Config name="Release COFF32|Win32" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
+if errorlevel 1 goto reportError
+dmd -m32mscoff -map &quot;$(OutDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; $(InputPath) ..\tools\nostacktrace.d user32.lib" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
+   <Config name="Debug|Win32" customcmd="dmd -g -map $(OutDir)\$(InputName).map -of$(OutDir)\$(InputName).exe $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
+  </File>
   <File path="dte_idl.bat" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError

--- a/build/build.visualdproj
+++ b/build/build.visualdproj
@@ -313,34 +313,34 @@ echo. &gt;&quot;$(TargetDir)\build.dep&quot;</postBuildCommand>
  </Config>
  <Folder name="build">
   <File path="dte_idl.bat" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
-if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; 
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 call $(InputPath) &quot;$(OutDir)\tlb2idl.exe&quot; &quot;$(OutDir)\dte_idl.success&quot;" tool="Custom" dependencies="&quot;$(OutDir)\tlb2idl.exe&quot;" outfile="$(OutDir)\dte_idl.success" />
   <File path="..\tools\filemonitor.d" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
-if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; 
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 dmd -g -map &quot;$(OutDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).dll&quot; -defaultlib=user32.lib -L/ENTRY:_DllMain@12 $(InputPath)" tool="Custom" outfile="$(OutDir)\$(InputName).dll" />
   <File path="..\tools\largeadr.d" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
-if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; 
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 dmd -map &quot;$(OutDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; $(InputPath)" tool="Custom" outfile="$(OutDir)\$(InputName).exe" />
   <File path="..\tools\pipedmd.d" customcmd="dmd -map $(OutDir)\$(InputName).map -of$(OutDir)\$(InputName).exe $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" perConfig="true" outfile="$(OutDir)\$(InputName).exe">
    <Config name="Release COFF32|Win32" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
-if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; 
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 dmd -m32mscoff -map &quot;$(OutDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; $(InputPath) ..\tools\nostacktrace.d user32.lib" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
    <Config name="Debug|Win32" customcmd="dmd -g -map $(OutDir)\$(InputName).map -of$(OutDir)\$(InputName).exe $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
   </File>
   <File path="sdk.bat" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
-if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; 
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 call $(InputPath) &quot;$(OutDir)\vsi2d.exe&quot; &quot;$(OutDir)\sdk.success&quot;" tool="Custom" dependencies="&quot;$(OutDir)\dte_idl.success&quot; &quot;$(OutDir)\vsi2d.exe&quot;" outfile="$(OutDir)\sdk.success" />
   <File path="sdk_libs.bat" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
-if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; 
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 call $(InputPath) &quot;$(OutDir)\vsi2d.exe&quot; &quot;$(OutDir)\sdk_libs.success&quot;" tool="Custom" outfile="$(OutDir)\sdk_libs.success" />
   <File path="..\tools\tlb2idl.d" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
-if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; 
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 dmd -d -map &quot;$(OutDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; $(InputPath) oleaut32.lib uuid.lib" tool="Custom" outfile="$(OutDir)\$(InputName).exe" />
  </Folder>

--- a/build/build.visualdproj
+++ b/build/build.visualdproj
@@ -95,6 +95,9 @@
   <deffile />
   <resfile />
   <exefile>$(IntDir)\$(ProjectName).sdk</exefile>
+  <pdbfile>$(IntDir)\$(SafeProjectName).pdb</pdbfile>
+  <impfile>$(IntDir)\$(SafeProjectName).lib</impfile>
+  <mapfile>$(IntDir)\$(SafeProjectName).map</mapfile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>2</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -198,6 +201,9 @@
   <deffile />
   <resfile />
   <exefile>$(IntDir)\$(ProjectName).sdk</exefile>
+  <pdbfile>$(IntDir)\$(SafeProjectName).pdb</pdbfile>
+  <impfile>$(IntDir)\$(SafeProjectName).lib</impfile>
+  <mapfile>$(IntDir)\$(SafeProjectName).map</mapfile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>1</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -302,6 +308,9 @@ echo. &gt;$(TargetDir)\build.dep</postBuildCommand>
   <deffile />
   <resfile />
   <exefile>$(IntDir)\$(ProjectName).sdk</exefile>
+  <pdbfile>$(IntDir)\$(SafeProjectName).pdb</pdbfile>
+  <impfile>$(IntDir)\$(SafeProjectName).lib</impfile>
+  <mapfile>$(IntDir)\$(SafeProjectName).map</mapfile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>1</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -315,7 +324,7 @@ echo. &gt;&quot;$(TargetDir)\build.dep&quot;</postBuildCommand>
   <File path="dte_idl.bat" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
-call $(InputPath) &quot;$(OutDir)\tlb2idl.exe&quot; &quot;$(IntDir)\dte_idl.success&quot;" tool="Custom" dependencies="&quot;$(OutDir)\tlb2idl.exe&quot;" outfile="$(OutDir)\dte_idl.success" />
+call $(InputPath) &quot;$(OutDir)\tlb2idl.exe&quot; &quot;$(IntDir)\dte_idl.success&quot;" tool="Custom" dependencies="&quot;$(OutDir)\tlb2idl.exe&quot;" outfile="$(IntDir)\dte_idl.success" />
   <File path="..\tools\filemonitor.d" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
@@ -341,7 +350,7 @@ dmd -m32mscoff -map &quot;$(IntDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(
   <File path="sdk.bat" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
-call $(InputPath) &quot;$(OutDir)\vsi2d.exe&quot; &quot;$(IntDir)\sdk.success&quot;" tool="Custom" dependencies="&quot;$(IntDir)\dte_idl.success&quot; &quot;$(OutDir)\vsi2d.exe&quot;" outfile="$(OutDir)\sdk.success" />
+call $(InputPath) &quot;$(OutDir)\vsi2d.exe&quot; &quot;$(IntDir)\sdk.success&quot;" tool="Custom" dependencies="&quot;$(IntDir)\dte_idl.success&quot; &quot;$(OutDir)\vsi2d.exe&quot;" outfile="$(IntDir)\sdk.success" />
   <File path="sdk_libs.bat" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError

--- a/build/build.visualdproj
+++ b/build/build.visualdproj
@@ -57,7 +57,7 @@
   <imppath />
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -94,7 +94,7 @@
   <libpaths />
   <deffile />
   <resfile />
-  <exefile>$(OutDir)\$(ProjectName).sdk</exefile>
+  <exefile>$(IntDir)\$(ProjectName).sdk</exefile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>2</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -160,7 +160,7 @@
   <imppath />
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -197,7 +197,7 @@
   <libpaths />
   <deffile />
   <resfile />
-  <exefile>$(OutDir)\$(ProjectName).sdk</exefile>
+  <exefile>$(IntDir)\$(ProjectName).sdk</exefile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>1</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -264,7 +264,7 @@ echo. &gt;$(TargetDir)\build.dep</postBuildCommand>
   <imppath />
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -301,7 +301,7 @@ echo. &gt;$(TargetDir)\build.dep</postBuildCommand>
   <libpaths />
   <deffile />
   <resfile />
-  <exefile>$(OutDir)\$(ProjectName).sdk</exefile>
+  <exefile>$(IntDir)\$(ProjectName).sdk</exefile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>1</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -312,43 +312,43 @@ echo. &gt;&quot;$(TargetDir)\build.dep&quot;</postBuildCommand>
   <filesToClean>*.obj;*.cmd;*.build;*.json;*.dep</filesToClean>
  </Config>
  <Folder name="build">
-  <File path="..\tools\mb2utf16.d" customcmd="dmd -map $(OutDir)\$(InputName).map -of$(OutDir)\$(InputName).exe $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" perConfig="true" outfile="$(OutDir)\$(InputName).exe">
-   <Config name="Release COFF32|Win32" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
-if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
-if errorlevel 1 goto reportError
-dmd -m32mscoff -map &quot;$(OutDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; $(InputPath) ..\tools\nostacktrace.d user32.lib" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
-   <Config name="Debug|Win32" customcmd="dmd -g -map $(OutDir)\$(InputName).map -of$(OutDir)\$(InputName).exe $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
-  </File>
   <File path="dte_idl.bat" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
-call $(InputPath) &quot;$(OutDir)\tlb2idl.exe&quot; &quot;$(OutDir)\dte_idl.success&quot;" tool="Custom" dependencies="&quot;$(OutDir)\tlb2idl.exe&quot;" outfile="$(OutDir)\dte_idl.success" />
+call $(InputPath) &quot;$(OutDir)\tlb2idl.exe&quot; &quot;$(IntDir)\dte_idl.success&quot;" tool="Custom" dependencies="&quot;$(OutDir)\tlb2idl.exe&quot;" outfile="$(OutDir)\dte_idl.success" />
   <File path="..\tools\filemonitor.d" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
-dmd -g -map &quot;$(OutDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).dll&quot; -defaultlib=user32.lib -L/ENTRY:_DllMain@12 $(InputPath)" tool="Custom" outfile="$(OutDir)\$(InputName).dll" />
+dmd -g -map &quot;$(IntDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).dll&quot; &quot;-od$(IntDir)&quot; -defaultlib=user32.lib -L/ENTRY:_DllMain@12 $(InputPath)" tool="Custom" outfile="$(OutDir)\$(InputName).dll" />
   <File path="..\tools\largeadr.d" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
-dmd -map &quot;$(OutDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; $(InputPath)" tool="Custom" outfile="$(OutDir)\$(InputName).exe" />
-  <File path="..\tools\pipedmd.d" customcmd="dmd -map $(OutDir)\$(InputName).map -of$(OutDir)\$(InputName).exe $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" perConfig="true" outfile="$(OutDir)\$(InputName).exe">
+dmd -map &quot;$(IntDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; &quot;-od$(IntDir)&quot; $(InputPath)" tool="Custom" outfile="$(OutDir)\$(InputName).exe" />
+  <File path="..\tools\mb2utf16.d" customcmd="dmd -map $(OutDir)\$(InputName).map -of$(IntDir)\$(InputName).exe $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" perConfig="true" outfile="$(OutDir)\$(InputName).exe">
    <Config name="Release COFF32|Win32" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
-dmd -m32mscoff -map &quot;$(OutDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; $(InputPath) ..\tools\nostacktrace.d user32.lib" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
-   <Config name="Debug|Win32" customcmd="dmd -g -map $(OutDir)\$(InputName).map -of$(OutDir)\$(InputName).exe $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
+dmd -m32mscoff -map &quot;$(IntDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; $(InputPath) ..\tools\nostacktrace.d user32.lib" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
+   <Config name="Debug|Win32" customcmd="dmd -g -map &quot;$(IntDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; &quot;-od$(IntDir)&quot; $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
+  </File>
+  <File path="..\tools\pipedmd.d" customcmd="dmd -map $(IntDir)\$(InputName).map -of$(OutDir)\$(InputName).exe $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" perConfig="true" outfile="$(OutDir)\$(InputName).exe">
+   <Config name="Release COFF32|Win32" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
+if errorlevel 1 goto reportError
+dmd -m32mscoff -map &quot;$(IntDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; $(InputPath) ..\tools\nostacktrace.d user32.lib" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
+   <Config name="Debug|Win32" customcmd="dmd -g -map &quot;$(IntDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; &quot;-od$(IntDir)&quot; $(InputPath) ..\tools\nostacktrace.d" tool="Custom" dependencies="..\tools\nostacktrace.d" outfile="$(OutDir)\$(InputName).exe" />
   </File>
   <File path="sdk.bat" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
-call $(InputPath) &quot;$(OutDir)\vsi2d.exe&quot; &quot;$(OutDir)\sdk.success&quot;" tool="Custom" dependencies="&quot;$(OutDir)\dte_idl.success&quot; &quot;$(OutDir)\vsi2d.exe&quot;" outfile="$(OutDir)\sdk.success" />
+call $(InputPath) &quot;$(OutDir)\vsi2d.exe&quot; &quot;$(IntDir)\sdk.success&quot;" tool="Custom" dependencies="&quot;$(IntDir)\dte_idl.success&quot; &quot;$(OutDir)\vsi2d.exe&quot;" outfile="$(OutDir)\sdk.success" />
   <File path="sdk_libs.bat" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
-call $(InputPath) &quot;$(OutDir)\vsi2d.exe&quot; &quot;$(OutDir)\sdk_libs.success&quot;" tool="Custom" outfile="$(OutDir)\sdk_libs.success" />
+call $(InputPath) &quot;$(OutDir)\vsi2d.exe&quot; &quot;$(IntDir)\sdk_libs.success&quot;" tool="Custom" outfile="$(IntDir)\sdk_libs.success" />
   <File path="..\tools\tlb2idl.d" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
-dmd -d -map &quot;$(OutDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; $(InputPath) oleaut32.lib uuid.lib" tool="Custom" outfile="$(OutDir)\$(InputName).exe" />
+dmd -d -map &quot;$(IntDir)\$(InputName).map&quot; &quot;-of$(OutDir)\$(InputName).exe&quot; &quot;-od$(IntDir)&quot; $(InputPath) oleaut32.lib uuid.lib" tool="Custom" outfile="$(OutDir)\$(InputName).exe" />
  </Folder>
 </DProject>

--- a/c2d/c2d.visualdproj
+++ b/c2d/c2d.visualdproj
@@ -57,7 +57,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -160,7 +160,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -572,7 +572,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1087,7 +1087,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1190,7 +1190,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1293,7 +1293,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1396,7 +1396,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1499,7 +1499,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1602,7 +1602,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>

--- a/c2d/cpp2d.visualdproj
+++ b/c2d/cpp2d.visualdproj
@@ -57,7 +57,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -160,7 +160,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -263,7 +263,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -366,7 +366,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -469,7 +469,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -572,7 +572,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -675,7 +675,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -778,7 +778,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -881,7 +881,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -984,7 +984,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1087,7 +1087,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1190,7 +1190,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1293,7 +1293,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1396,7 +1396,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1499,7 +1499,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1602,7 +1602,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>

--- a/c2d/vsi2d.visualdproj
+++ b/c2d/vsi2d.visualdproj
@@ -57,7 +57,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -160,7 +160,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -263,7 +263,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -366,7 +366,7 @@
   <imppath />
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -469,7 +469,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -572,7 +572,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -675,7 +675,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -778,7 +778,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -881,7 +881,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -984,7 +984,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1087,7 +1087,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1190,7 +1190,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1293,7 +1293,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1396,7 +1396,7 @@
   <imppath>..</imppath>
   <fileImppath>..</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>

--- a/doc/StartPage.dd
+++ b/doc/StartPage.dd
@@ -54,6 +54,14 @@ $(H2 News)
 $(P $(LINK2 VersionHistory.html, Full version history and complete details...)
 )
 
+2017-08-17 Version 0.45.1
+ $(UL
+  $(LI now building against the VC runtime to avoid
+      anti-virus programs blocking the installation or execution)
+  $(LI improved tooltips)
+  $(LI mago: fix displaying long strings as empty)
+ )
+
 2017-08-03 Version 0.45.0
  $(UL
   $(LI improved integration for VS2017)

--- a/doc/VersionHistory.dd
+++ b/doc/VersionHistory.dd
@@ -1,5 +1,36 @@
 Ddoc
 
+$(H2 2017-08-17 Version 0.45.1)
+ $(UL
+  $(LI installation
+   $(UL
+    $(LI now building against the VC runtime (-m32mscoff) instead of the DigitalMars runtime to avoid
+      anti-virus programs blocking the installation or execution)
+  ))
+  $(LI DParser semantic engine:
+   $(UL
+    $(LI "add import path of project dependencies": implicit import directories not passed to semantic analyzer)
+    $(LI tooltip for selective imports now show the aliased definition, not the alias)
+    $(LI improved tooltips: show fully qualified name, show initializer for constants,
+      better display for enum and aliases)
+    $(LI fixed completion or tooltips sometimes not working before modifying source code)
+  ))
+  $(LI build system
+   $(UL
+    $(LI fix dependencies for custom build rules if file names contain spaces)
+    $(LI fix tracker invocation if the VS2015 version is found through PATH)
+  ))
+  $(LI mago debugger:
+   $(UL
+    $(LI fix displaying long strings as empty)
+  ))
+  $(LI build
+   $(UL
+    $(LI update vsi2d to Windows SDK 10.0.15063.0)
+    $(LI Visual D now buildable with VS2017)
+  ))
+ )
+
 $(H2 2017-08-01 Version 0.45.0)
  $(UL
   $(LI installation

--- a/doc/visuald.ddoc
+++ b/doc/visuald.ddoc
@@ -1,4 +1,4 @@
-VERSION = 0.45.0
+VERSION = 0.45.1
 ROOT_DIR = http://www.dlang.org/
 ROOT = http://www.dlang.org
 BODYCLASS = visuald

--- a/nsis/visuald.nsi
+++ b/nsis/visuald.nsi
@@ -202,6 +202,7 @@ Section "Visual Studio package" SecPackage
   ${File} "..\bin\${CONFIG}\" ${DLLNAME}
   ${File} "..\bin\${CONFIG}\" vdserver.tlb
   ${File} "..\bin\${CONFIG}\" pipedmd.exe
+  ${File} "..\bin\${CONFIG}\" mb2utf16.exe
   ;; ${File} "..\bin\${CONFIG}\" filemonitor.dll
   ${File} "..\bin\Release\" dcxxfilt.exe
   ${File} ..\ README.md

--- a/sdk/vsi.visualdproj
+++ b/sdk/vsi.visualdproj
@@ -57,7 +57,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -160,7 +160,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -263,7 +263,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -366,7 +366,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -469,7 +469,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -572,7 +572,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -675,7 +675,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -778,7 +778,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -881,7 +881,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -984,7 +984,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1087,7 +1087,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1190,7 +1190,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1293,7 +1293,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1396,7 +1396,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1499,7 +1499,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1602,7 +1602,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vsi</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1766,6 +1766,7 @@
    <File path="win32\utilapiset.d" />
    <File path="win32\ioapiset.d" />
    <File path="win32\threadpoolapiset.d" />
+   <File path="win32\bemapiset.d" />
    <File path="win32\wow64apiset.d" />
    <File path="win32\jobapi.d" />
    <File path="win32\timezoneapi.d" />
@@ -1784,11 +1785,6 @@
    <File path="win32\mprapidef.d" />
    <File path="win32\lmerr.d" />
    <File path="win32\lmcons.d" />
-   <File path="win32\coml2api.d" />
-   <File path="win32\jobapi2.d" />
-   <File path="win32\propidlbase.d" />
-   <File path="win32\enclaveapi.d" />
-   <File path="win32\dpa_dsa.d" />
   </Folder>
   <Folder name="vsi">
    <File path="vsi\sdk_shared.d" />

--- a/stdext/file.d
+++ b/stdext/file.d
@@ -91,7 +91,7 @@ string[string][string] parseIniText(string txt)
 			}
 			currentSection = ln[1..pos];
 		}
-		else 
+		else
 		{
 			content ~= ln ~ "\n";
 			if ((pos = indexOf(ln, '=')) >= 1)
@@ -126,11 +126,19 @@ string[2][] parseIniSectionAssignments(string txt)
 	return values;
 }
 
-string[string][string] parseIni(string fname)
+string[string][string] parseIni(string fname, bool utf8)
 {
 	try
 	{
-		string txt = to!string(std.file.read(fname));
+		import std.windows.charset;
+
+		void[] content = std.file.read(fname);
+		string txt;
+		if (utf8)
+			txt = to!string(content);
+		else
+			txt = fromMBSz((cast(string)content ~ '0').ptr);
+
 		return parseIniText(txt);
 	}
 	catch(Exception e)

--- a/stdext/libconfig.d
+++ b/stdext/libconfig.d
@@ -1,0 +1,639 @@
+//===-- originally driver/config.d - LDC config file parsing -----------------*- D -*-===//
+//
+//              taken from LDC – the LLVM D compiler
+//
+// This file is distributed under the BSD-style LDC license:
+//
+// Copyright (c) 2007-2017 LDC Team.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//       this list of conditions and the following disclaimer in the documentation
+//       and/or other materials provided with the distribution.
+//     * Neither the name of the LDC Team nor the names of its contributors may be
+//       used to endorse or promote products derived from this software without
+//       specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//===----------------------------------------------------------------------===//
+//
+// Parsing engine for the LDC config file (ldc2.conf).
+//
+//===----------------------------------------------------------------------===//
+module stdext.libconfig;
+
+import core.stdc.ctype;
+import core.stdc.stdio;
+import core.stdc.string;
+
+
+class Setting
+{
+    enum Type
+    {
+        scalar,
+        array,
+        group,
+    }
+
+    this(string name, Type type)
+    {
+        _name = name;
+        _type = type;
+    }
+
+    @property string name() const
+    {
+        return _name;
+    }
+
+    @property Type type() const
+    {
+        return _type;
+    }
+
+    private string _name;
+    private Type _type;
+}
+
+
+class ScalarSetting : Setting
+{
+    this(string name, string val)
+    {
+        super(name, Type.scalar);
+        _val = val;
+    }
+
+    @property string val() const
+    {
+        return _val;
+    }
+
+    private string _val;
+}
+
+
+class ArraySetting : Setting
+{
+    this(string name, string[] vals)
+    {
+        super(name, Type.array);
+        _vals = vals;
+    }
+
+    @property const(string)[] vals() const
+    {
+        return _vals;
+    }
+
+    private string[] _vals;
+}
+
+class GroupSetting : Setting
+{
+    this(string name, Setting[] children)
+    {
+        super(name, Type.group);
+        _children = children;
+    }
+
+    @property const(Setting)[] children() const
+    {
+        return _children;
+    }
+
+    private Setting[] _children;
+}
+
+Setting[] parseConfigFile(string filename)
+{
+	import std.file;
+    auto content = std.file.read(filename);
+
+    // skip UTF-8 BOM
+    int start = 0;
+    if (content.length >= 3 && content[0 .. 3] == "\xEF\xBB\xBF")
+        start = 3;
+    content = content[start .. $];
+
+    auto parser = Parser(cast(string) content, filename);
+    return parser.parseConfig();
+}
+
+Setting[] parseConfigFile(const(char)* filename)
+{
+    auto dFilename = filename[0 .. strlen(filename)].idup;
+
+    auto file = fopen(filename, "r");
+    if (!file)
+    {
+        throw new Exception("could not open config file " ~
+                            dFilename ~ " for reading");
+    }
+
+    fseek(file, 0, SEEK_END);
+    const fileLength = ftell(file);
+    rewind(file);
+
+    auto content = new char[fileLength];
+    const numRead = fread(content.ptr, 1, fileLength, file);
+    fclose(file);
+
+    // skip UTF-8 BOM
+    int start = 0;
+    if (numRead >= 3 && content[0 .. 3] == "\xEF\xBB\xBF")
+        start = 3;
+    content = content[start .. numRead];
+
+    auto parser = Parser(cast(string) content, dFilename);
+    return parser.parseConfig();
+}
+
+
+private:
+
+/+
+
+What follows is a recursive descent parser that reads the following
+EBNF grammar.
+It is a subset of the libconfig grammar (http://www.hyperrealm.com/libconfig).
+
+config  =   { ows , setting } , ows ;
+setting =   name , (":" | "=") , value , [";" | ","] ;
+name    =   alpha , { alpha | digit | "_" | "-" } ;
+value   =   string | array | group ;
+array   =   "[" , ows ,
+                { string , ows , "," , ows } ,
+            "]" ;
+group   =   "{" , ows , { setting , ows } , "}" ;
+string  =   ( quotstr , { ows , quotstr } ) |
+            ( btstr , { ows, btstr } ) ;
+quotstr =   '"' , { ? any char but '"', '\n' and '\r' ? | escseq } , '"' ;
+escseq  =   "\" , ["\" | '"' | "r" | "n" | "t" ] ;
+btstr   =   '`' , { ? any char but '`' ? } , '`' ;
+alpha   =   ? any char between "a" and "z" included
+                    or between "A" and "Z" included ? ;
+digit   =   ? any char between "0" and "9" included ? ;
+ows     =   [ ws ] ; (* optional white space *)
+ws      =   ? white space (space, tab, line feed ...) ? ;
+
+
+Single line comments are also supported. They start with "//" and span until
+line feed.
+The "//" sequence is however allowed within strings and doesn't need to be
+escaped.
+White space are significant only within strings.
+Physical line feeds are not allowed within strings. To span a string over
+multiple lines, use concatenation ("hello " "world" == "hello world").
+The following escape sequences are allowed in strings:
+  - \\
+  - \"
+  - \r
+  - \n
+  - \t
+
++/
+
+enum Token
+{
+    name,
+    assign,         // ':' or '='
+    str,
+    lbrace,         // '{'
+    rbrace,         // '}'
+    lbracket,       // '['
+    rbracket,       // ']'
+    semicolon,      // ';'
+    comma,          // ','
+    unknown,
+    eof,
+}
+
+string humanReadableToken(in Token tok)
+{
+    final switch(tok)
+    {
+    case Token.name:        return `"name"`;
+    case Token.assign:      return `':' or '='`;
+    case Token.str:         return `"string"`;
+    case Token.lbrace:      return `'{'`;
+    case Token.rbrace:      return `'}'`;
+    case Token.lbracket:    return `'['`;
+    case Token.rbracket:    return `']'`;
+    case Token.semicolon:   return `';'`;
+    case Token.comma:       return `','`;
+    case Token.unknown:     return `"unknown token"`;
+    case Token.eof:         return `"end of file"`;
+    }
+}
+
+struct Parser
+{
+    string filename;
+    string content;
+    int index;
+    int lineNum = 1;
+
+    char lastChar = ' ';
+
+    static struct Ahead
+    {
+        Token tok;
+        string s;
+    }
+    Ahead ahead;
+    Ahead* aheadp;
+
+    this(string content, string filename = null)
+    {
+        this.filename = filename;
+        this.content = content;
+    }
+
+    void error(in string msg)
+    {
+        enum fmt = "Error while reading config file: %.*s\nline %d: %.*s";
+        char[1024] buf;
+        auto len = snprintf(buf.ptr, buf.length, fmt, filename.length,
+                            filename.ptr, lineNum, msg.length, msg.ptr);
+        throw new Exception(buf[0 .. len].idup);
+    }
+
+    char getChar()
+    {
+        if (index == content.length)
+            return '\0';
+        const c = content[index++];
+        if (c == '\n')
+            ++lineNum;
+        return c;
+    }
+
+    Token getTok(out string outStr)
+    {
+        if (aheadp)
+        {
+            immutable tok = aheadp.tok;
+            outStr = aheadp.s;
+            aheadp = null;
+            return tok;
+        }
+
+        while (isspace(lastChar))
+        {
+            lastChar = getChar();
+        }
+
+        if (lastChar == '/')
+        {
+            lastChar = getChar();
+            if (lastChar != '/')
+            {
+                outStr = "/";
+                return Token.unknown;
+            }
+
+            do
+            {
+                lastChar = getChar();
+            }
+            while (lastChar != '\n' && lastChar != '\0');
+            return getTok(outStr);
+        }
+
+        if (isalpha(lastChar))
+        {
+            string name;
+            do
+            {
+                name ~= lastChar;
+                lastChar = getChar();
+            }
+            while (isalnum(lastChar) || lastChar == '_' || lastChar == '-');
+            outStr = name;
+            return Token.name;
+        }
+
+        switch (lastChar)
+        {
+        case ':':
+        case '=':
+            lastChar = getChar();
+            return Token.assign;
+        case ';':
+            lastChar = getChar();
+            return Token.semicolon;
+        case ',':
+            lastChar = getChar();
+            return Token.comma;
+        case '{':
+            lastChar = getChar();
+            return Token.lbrace;
+        case '}':
+            lastChar = getChar();
+            return Token.rbrace;
+        case '[':
+            lastChar = getChar();
+            return Token.lbracket;
+        case ']':
+            lastChar = getChar();
+            return Token.rbracket;
+        case '\0':
+            return Token.eof;
+        default:
+            break;
+        }
+
+        if (lastChar == '"')
+        {
+            string str;
+            while (lastChar == '"')
+            {
+                while (1)
+                {
+                    lastChar = getChar();
+                    if (lastChar == '"') break;
+                    if (lastChar == '\n' || lastChar == '\r')
+                    {
+                        error("Unexpected end of line in string literal");
+                    }
+                    else if (lastChar == '\0')
+                    {
+                        error("Unexpected end of file in string literal");
+                    }
+                    if (lastChar == '\\')
+                    {
+                        lastChar = getChar();
+                        switch(lastChar)
+                        {
+                        case '\\':
+                        case '"':
+                            break;
+                        case 'r':
+                            lastChar = '\r';
+                            break;
+                        case 'n':
+                            lastChar = '\n';
+                            break;
+                        case 't':
+                            lastChar = '\t';
+                            break;
+                        default:
+                            error("Unexpected escape sequence: \\" ~ lastChar);
+                            break;
+                        }
+                    }
+                    str ~= lastChar;
+                }
+                lastChar = getChar();
+                while (isspace(lastChar)) lastChar = getChar();
+            }
+
+            outStr = str;
+            return Token.str;
+        }
+
+        if (lastChar == '`')
+        {
+            string str;
+            while (lastChar == '`')
+            {
+                while (1)
+                {
+                    lastChar = getChar();
+                    if (lastChar == '`') break;
+                    if (lastChar == '\0')
+                    {
+                        error("Unexpected end of file in string literal");
+                    }
+                    str ~= lastChar;
+                }
+                lastChar = getChar();
+                while (isspace(lastChar)) lastChar = getChar();
+            }
+
+            outStr = str;
+            return Token.str;
+        }
+
+        outStr = [lastChar];
+        lastChar = getChar();
+        return Token.unknown;
+    }
+
+    void ungetTok(in Token tok, in string s)
+    {
+        assert(!aheadp, "can only have one look ahead");
+        ahead.tok = tok;
+        ahead.s = s;
+        aheadp = &ahead;
+    }
+
+    void unexpectedTokenError(in Token tok, in Token expected, string s)
+    {
+        s = s.length ? " ("~s~")" : "";
+        error("Was expecting token " ~ humanReadableToken(expected) ~
+              ". Got " ~ humanReadableToken(tok) ~ s ~ " instead.");
+    }
+
+    string accept(in Token expected)
+    {
+        string s;
+        immutable tok = getTok(s);
+        if (tok != expected)
+        {
+            unexpectedTokenError(tok, expected, s);
+        }
+        return s;
+    }
+
+    Setting[] parseConfig()
+    {
+        Setting[] res;
+        while (1)
+        {
+            {
+                string s;
+                auto t = getTok(s);
+                if (t == Token.eof)
+                {
+                    break;
+                }
+                ungetTok(t, s);
+            }
+            res ~= parseSetting();
+        }
+        return res;
+    }
+
+    Setting parseSetting()
+    {
+        immutable name = accept(Token.name);
+
+        accept(Token.assign);
+
+        Setting res = parseValue(name);
+
+        string s;
+        immutable t = getTok(s);
+        if (t != Token.semicolon && t != Token.comma)
+        {
+            ungetTok(t, s);
+        }
+
+        return res;
+    }
+
+    Setting parseValue(string name)
+    {
+        string s;
+        auto t = getTok(s);
+        if (t == Token.str)
+        {
+            return new ScalarSetting(name, s);
+        }
+        else if (t == Token.lbracket)
+        {
+            string[] arrVal;
+            while (1)
+            {
+                // get string or rbracket
+                t = getTok(s);
+                switch(t)
+                {
+                case Token.str:
+                    arrVal ~= s;
+                    break;
+                case Token.rbracket:
+                    return new ArraySetting(name, arrVal);
+                default:
+                    unexpectedTokenError(t, Token.str, s);
+                    assert(false);
+                }
+
+                // get comma or rbracket
+                t = getTok(s);
+                switch(t)
+                {
+                case Token.comma:
+                    break;
+                case Token.rbracket:
+                    return new ArraySetting(name, arrVal);
+                default:
+                    unexpectedTokenError(t, Token.comma, s);
+                    assert(false);
+                }
+            }
+        }
+        else if (t == Token.lbrace)
+        {
+            Setting[] grpVal;
+            while (1)
+            {
+                t = getTok(s);
+                if (t == Token.rbrace)
+                {
+                    return new GroupSetting(name, grpVal);
+                }
+                ungetTok(t, s);
+                grpVal ~= parseSetting();
+            }
+        }
+        error("Was expecting value.");
+        assert(false);
+    }
+}
+
+unittest
+{
+    static void testScalar(string input, string expected)
+    {
+        auto setting = Parser(input).parseValue(null);
+        assert(setting.type == Setting.Type.scalar);
+        assert((cast(ScalarSetting) setting).val == expected);
+    }
+
+    testScalar(`""`, "");
+    testScalar(`"abc\r\ndef\t\"quoted/\\123\""`,
+                "abc\r\ndef\t\"quoted/\\123\"");
+    testScalar(`"concatenated" " multiline"
+                " strings"`, "concatenated multiline strings");
+    testScalar("`abc\n\\ //comment \"`",
+                "abc\n\\ //comment \"");
+    testScalar(`"Üņïčöđë"`, "Üņïčöđë");
+}
+
+unittest
+{
+    static void testArray(string input, string[] expected)
+    {
+        auto setting = Parser(input).parseValue(null);
+        assert(setting.type == Setting.Type.array);
+        assert((cast(ArraySetting) setting).vals == expected);
+    }
+
+    testArray(`[]`, []);
+    testArray(`[ "a" ]`, [ "a" ]);
+    testArray(`[ "a", ]`, [ "a" ]);
+    testArray(`[ "a", "b" ]`, [ "a", "b" ]);
+    testArray(`[
+            // comment
+            "a",
+            // comment
+            "b"
+        ]`, [ "a", "b" ]);
+}
+
+unittest
+{
+    enum input =
+`// comment
+
+// comment
+group-1: {};
+// comment
+Group-2:
+{
+    // comment
+    scalar = "abc";
+    // comment
+    Array_1 = [ "a" ];
+};
+`;
+
+    auto settings = Parser(input).parseConfig();
+    assert(settings.length == 2);
+
+    assert(settings[0].name == "group-1");
+    assert(settings[0].type == Setting.Type.group);
+    assert((cast(GroupSetting) settings[0]).children == []);
+
+    assert(settings[1].name == "Group-2");
+    assert(settings[1].type == Setting.Type.group);
+    auto group2 = cast(GroupSetting) settings[1];
+    assert(group2.children.length == 2);
+
+    assert(group2.children[0].name == "scalar");
+    assert(group2.children[0].type == Setting.Type.scalar);
+    assert((cast(ScalarSetting) group2.children[0]).val == "abc");
+
+    assert(group2.children[1].name == "Array_1");
+    assert(group2.children[1].type == Setting.Type.array);
+    assert((cast(ArraySetting) group2.children[1]).vals == [ "a" ]);
+}

--- a/stdext/stdext.visualdproj
+++ b/stdext/stdext.visualdproj
@@ -57,7 +57,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -160,7 +160,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -263,7 +263,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -366,7 +366,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -469,7 +469,7 @@
   <imppath />
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -572,7 +572,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -675,7 +675,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -778,7 +778,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -881,7 +881,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -984,7 +984,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1087,7 +1087,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1190,7 +1190,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1293,7 +1293,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1396,7 +1396,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1499,7 +1499,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1602,7 +1602,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>

--- a/stdext/stdext.visualdproj
+++ b/stdext/stdext.visualdproj
@@ -1655,6 +1655,7 @@
   <File path="ddocmacros.d" />
   <File path="file.d" />
   <File path="httpget.d" />
+  <File path="libconfig.d" />
   <File path="path.d" />
   <File path="registry.d" />
   <File path="string.d" />

--- a/stdext/string.d
+++ b/stdext/string.d
@@ -152,6 +152,11 @@ int visiblePosition(S)(S txt, int tabSize, int idx)
 	return p;
 }
 
+int nextTabPosition(int n, int tabSize)
+{
+	return n + tabSize - n % tabSize;
+}
+
 S createVisualSpaces(S)(int n, int tabSize, int tabOff = 0)
 {
 	S s;

--- a/stdext/string.d
+++ b/stdext/string.d
@@ -370,3 +370,11 @@ dchar decodeBwd(Char)(const(Char) txt, ref size_t pos)
 	assert(pos + len == p);
 	return ch;
 }
+
+bool isASCIIString(string s)
+{
+	foreach (dchar c; s)
+		if (!isASCII(c))
+			return false;
+	return true;
+}

--- a/tools/mb2utf16.d
+++ b/tools/mb2utf16.d
@@ -1,0 +1,17 @@
+import std.file;
+import std.utf;
+import std.windows.charset;
+import core.sys.windows.winuser;
+
+void main(string[] argv)
+{
+	int cp = GetKBCodePage();
+	string input = argv[1];
+	string output = (argv.length > 2 ? argv[2] : input);
+
+	void[] content = std.file.read(input);
+	string str8 = fromMBSz((cast(string)content ~ '\0').ptr, cp);
+	wstring str16 = toUTF16(str8);
+	ubyte[2] bom = [ 0xff, 0xfe ];
+	std.file.write(output, bom ~ cast(ubyte[])str16);
+}

--- a/vdc/parser.visualdproj
+++ b/vdc/parser.visualdproj
@@ -57,7 +57,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -160,7 +160,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -263,7 +263,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -366,7 +366,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -469,7 +469,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -572,7 +572,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -675,7 +675,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -778,7 +778,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -881,7 +881,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -984,7 +984,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1087,7 +1087,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1190,7 +1190,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1293,7 +1293,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1396,7 +1396,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)\$(PLATFORMNAME)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1499,7 +1499,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1602,7 +1602,7 @@
   <imppath>..</imppath>
   <fileImppath>.</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\parser</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>

--- a/vdc/vdserver.visualdproj
+++ b/vdc/vdserver.visualdproj
@@ -1443,10 +1443,12 @@
   <filesToClean>*.obj;*.cmd;*.build;*.json;*.dep</filesToClean>
  </Config>
  <Folder name="vdserver">
-  <File path="vdserver.idl" customcmd="call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
+  <File path="vdserver.idl" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 midl /D _DEBUG /nologo /char signed /env win32 /Oicf  /out &quot;$(OutDir)&quot; /error stub_data $(InputPath)" tool="Custom" outfile="$(OutDir)/vdserver.tlb" />
-  <File path="vdserver.rc" customcmd="call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
+  <File path="vdserver.rc" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 rc /fo&quot;$(OutDir)\vdserver.res&quot; &quot;/I$(OutDir)&quot; $(InputPath)" tool="Custom" dependencies="&quot;$(OutDir)\vdserver.tlb&quot; ..\version" linkoutput="true" outfile="$(OutDir)\vdserver.res" />
   <File path="vdserver.reg" />

--- a/vdc/vdserver.visualdproj
+++ b/vdc/vdserver.visualdproj
@@ -57,7 +57,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -160,7 +160,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -263,7 +263,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -366,7 +366,7 @@
   <imppath />
   <fileImppath />
   <outdir>$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -469,7 +469,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -572,7 +572,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\x64</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -675,7 +675,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -778,7 +778,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\x64</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -881,7 +881,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -984,7 +984,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1087,7 +1087,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1190,7 +1190,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)\x64</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1293,7 +1293,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1396,7 +1396,7 @@
   <imppath>..</imppath>
   <fileImppath />
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\vdserver</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -1446,7 +1446,7 @@
   <File path="vdserver.idl" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
-midl /D _DEBUG /nologo /char signed /env win32 /Oicf  /out &quot;$(OutDir)&quot; /error stub_data $(InputPath)" tool="Custom" outfile="$(OutDir)/vdserver.tlb" />
+midl /D _DEBUG /nologo /char signed /env win32 /Oicf  /tlb &quot;..\vdserver.tlb&quot; /out &quot;$(IntDir)&quot; /error stub_data $(InputPath)" tool="Custom" outfile="$(OutDir)/vdserver.tlb" />
   <File path="vdserver.rc" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError

--- a/visuald/build.d
+++ b/visuald/build.d
@@ -305,7 +305,7 @@ else
 			{
 				string workdir = mConfig.GetProjectDir();
 				string outfile = mConfig.GetOutputFile(file);
-				string cmdfile = makeFilenameAbsolute(outfile ~ "." ~ kCmdLogFileExtension, workdir);
+				string cmdfile = mConfig.getCustomCommandFile(outfile);
 				showUptodateFailure(reason, outfile);
 				removeCachedFileTime(makeFilenameAbsolute(outfile, workdir));
 				HRESULT hr = RunCustomBuildBatchFile(outfile, cmdfile, cmdline, m_pIVsOutputWindowPane, this);
@@ -328,7 +328,7 @@ else
 			{
 				string workdir = mConfig.GetProjectDir();
 				string outfile = mConfig.GetPhobosPath();
-				string cmdfile = makeFilenameAbsolute(outfile ~ "." ~ kCmdLogFileExtension, workdir);
+				string cmdfile = mConfig.getCustomCommandFile(outfile);
 				showUptodateFailure(reason, outfile);
 				removeCachedFileTime(makeFilenameAbsolute(outfile, workdir));
 				HRESULT hr = RunCustomBuildBatchFile(outfile, cmdfile, cmdline, m_pIVsOutputWindowPane, this);

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -1060,7 +1060,7 @@ class ProjectOptions
 			return linkDMDCommandLine(isX86_64);
 	}
 
-	string getOutputDirOption()
+	string getObjectDirOption()
 	{
 		switch(compiler)
 		{
@@ -3135,7 +3135,7 @@ class Config :	DisposingComObject,
 						remove ~= f;
 					else
 					{
-						targetObj = "$(OutDir)\\$(ProjectName)." ~ mProjectOptions.objectFileExtension();
+						targetObj = "$(IntDir)\\$(ProjectName)." ~ mProjectOptions.objectFileExtension();
 						f = targetObj;
 					}
 				}
@@ -3404,10 +3404,13 @@ class Config :	DisposingComObject,
 				if(fcmd.length == 0)
 					opt = ""; // don't try to build zero files
 				else if(singleObj)
-					opt ~= " -c" ~ mProjectOptions.getOutputFileOption("$(OutDir)\\$(ProjectName)." ~ mProjectOptions.objectFileExtension());
+					opt ~= " -c" ~ mProjectOptions.getOutputFileOption("$(IntDir)\\$(ProjectName)." ~ mProjectOptions.objectFileExtension());
 				else
-					opt ~= " -c" ~ mProjectOptions.getOutputDirOption();
+					opt ~= " -c" ~ mProjectOptions.getObjectDirOption();
 			}
+			else
+				opt ~= mProjectOptions.getObjectDirOption(); // dmd writes object file to $(OutDir) otherwise
+
 			string addopt;
 			if(mProjectOptions.additionalOptions.length && fcmd.length)
 				addopt = " " ~ mProjectOptions.additionalOptions.replace("\n", " ");

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -820,6 +820,9 @@ class ProjectOptions
 			}
 			if (mslink && lib == OutputType.DLL)
 				cmd ~= " -L/DLL";
+
+			if (mslink && Package.GetGlobalOptions().isVS2017)
+				cmd ~= " /noopttls"; // update 15.3.1 moves TLS into _DATA segment
 		}
 		return cmd;
 	}
@@ -1009,6 +1012,9 @@ class ProjectOptions
 
 		if(mslink)
 		{
+			if (Package.GetGlobalOptions().isVS2017)
+				cmd ~= " /noopttls"; // update 15.3.1 moves TLS into _DATA segment
+
 			switch(cRuntime)
 			{
 				case CRuntime.None:           cmd ~= " /NODEFAULTLIB:libcmt"; break;
@@ -1093,7 +1099,7 @@ class ProjectOptions
 			if (std.file.exists(Package.GetGlobalOptions().VCInstallDir ~ "vcvarsall.bat"))
 				cmd = `call "%VCINSTALLDIR%\vcvarsall.bat" ` ~ (isX86_64 ? "x86_amd64" : "x86") ~ "\n" ~ cmd;
 			else if (std.file.exists(Package.GetGlobalOptions().VCInstallDir ~ r"Auxiliary\Build\vcvarsall.bat"))
-				cmd = `call "%VCINSTALLDIR%\Auxiliary\Build\vcvarsall.bat" ` ~ (isX86_64 ? "x86_amd64" : "x86") ~ "\n" ~ cmd;
+				cmd = "pushd .\n" ~ `call "%VCINSTALLDIR%\Auxiliary\Build\vcvarsall.bat" ` ~ (isX86_64 ? "x86_amd64" : "x86") ~ "\n" ~ "popd\n" ~ cmd;
 		}
 
 		static string[4] outObj = [ " -o", " -Fo", " -o", " -o " ];

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -220,6 +220,7 @@ class ProjectOptions
 	bool dump_source;
 	uint mapverbosity;
 	bool createImplib;
+	bool debuglib;      // use debug library
 
 	string defaultlibname;	// default library for non-debug builds
 	string debuglibname;	// default library for debug builds
@@ -806,6 +807,9 @@ class ProjectOptions
 
 		if(lib != OutputType.StaticLib)
 		{
+			if(compiler == Compiler.LDC && debuglib)
+				cmd ~= " -link-debuglib";
+
 			if (symdebug && mslink)
 				cmd ~= " -L/PDB:" ~ quoteFilename(pdbfile);
 
@@ -1381,6 +1385,7 @@ class ProjectOptions
 		elem ~= new xml.Element("dump_source", toElem(dump_source));
 		elem ~= new xml.Element("mapverbosity", toElem(mapverbosity));
 		elem ~= new xml.Element("createImplib", toElem(createImplib));
+		elem ~= new xml.Element("debuglib", toElem(debuglib));
 
 		elem ~= new xml.Element("defaultlibname", toElem(defaultlibname));
 		elem ~= new xml.Element("debuglibname", toElem(debuglibname));
@@ -1515,6 +1520,7 @@ class ProjectOptions
 		fromElem(elem, "dump_source", dump_source);
 		fromElem(elem, "mapverbosity", mapverbosity);
 		fromElem(elem, "createImplib", createImplib);
+		fromElem(elem, "debuglib", debuglib);
 
 		fromElem(elem, "defaultlibname", defaultlibname);
 		fromElem(elem, "debuglibname", debuglibname);

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -1223,13 +1223,17 @@ class ProjectOptions
 
 	bool usesCv2pdb()
 	{
+		if (runCv2pdb == 2)
+			return true;
+		if (runCv2pdb == 0)
+			return false;
 		if(compiler == Compiler.DMD && (isX86_64 || mscoff))
+			return false; // should generate correct debug info directly
+		if(compiler == Compiler.LDC && !isLDCforMinGW())
 			return false; // should generate correct debug info directly
 		if (!symdebug || lib == OutputType.StaticLib)
 			return false;
-		if (runCv2pdb == 2)
-			return true;
-		return (runCv2pdb == 1 && debugEngine != 1); // not for mago
+		return (debugEngine != 1); // not for mago
 	}
 
 	bool usesMSLink()

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -2704,6 +2704,14 @@ class Config :	DisposingComObject,
 		return null;
 	}
 
+	string getCustomCommandFile(string outfile)
+	{
+		string workdir = GetProjectDir();
+		string cmdfile = std.path.buildPath(GetIntermediateDir(), baseName(outfile) ~ "." ~ kCmdLogFileExtension);
+		cmdfile = makeFilenameAbsolute(cmdfile, workdir);
+		return cmdfile;
+	}
+
 	bool isUptodate(CFileNode file, string* preason)
 	{
 		string fcmd = GetCompileCommand(file);
@@ -2714,7 +2722,7 @@ class Config :	DisposingComObject,
 		outfile = mProjectOptions.replaceEnvironment(outfile, this, file.GetFilename(), outfile);
 
 		string workdir = GetProjectDir();
-		string cmdfile = makeFilenameAbsolute(outfile ~ "." ~ kCmdLogFileExtension, workdir);
+		string cmdfile = getCustomCommandFile(outfile);
 
 		if(!compareCommandFile(cmdfile, fcmd))
 		{
@@ -2889,7 +2897,7 @@ class Config :	DisposingComObject,
 					if (outname.length && outname != file.GetFilename())
 					{
 						files ~= makeFilenameAbsolute(outname, workdir);
-						files ~= makeFilenameAbsolute(outname ~ "." ~ kCmdLogFileExtension, workdir);
+						string cmdfile = getCustomCommandFile(outname);
 					}
 				}
 				return false;
@@ -3408,7 +3416,7 @@ class Config :	DisposingComObject,
 				else
 					opt ~= " -c" ~ mProjectOptions.getObjectDirOption();
 			}
-			else
+			else if (mProjectOptions.lib != OutputType.StaticLib) // dmd concatenates object dir and output file
 				opt ~= mProjectOptions.getObjectDirOption(); // dmd writes object file to $(OutDir) otherwise
 
 			string addopt;

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -822,7 +822,7 @@ class ProjectOptions
 				cmd ~= " -L/DLL";
 
 			if (mslink && Package.GetGlobalOptions().isVS2017)
-				cmd ~= " /noopttls"; // update 15.3.1 moves TLS into _DATA segment
+				cmd ~= " -L/noopttls"; // update 15.3.1 moves TLS into _DATA segment
 		}
 		return cmd;
 	}

--- a/visuald/dlangsvc.d
+++ b/visuald/dlangsvc.d
@@ -852,7 +852,7 @@ class LanguageService : DisposingComObject,
 		if(!cfg)
 			cfg = getCurrentStartupConfig();
 
-		string[] imp = GetImportPaths(cfg) ~ Package.GetGlobalOptions().getImportPaths();
+		string[] imp;
 		string[] stringImp;
 		string[] versionids;
 		string[] debugids;
@@ -863,6 +863,7 @@ class LanguageService : DisposingComObject,
 			scope(exit) release(cfg);
 			auto cfgopts = cfg.GetProjectOptions();
 			auto globopts = Package.GetGlobalOptions();
+			imp = GetImportPaths(cfg) ~ Package.GetGlobalOptions().getImportPaths(cfgopts.compiler);
 			flags = ConfigureFlags!()(cfgopts.useUnitTests, !cfgopts.release, cfgopts.isX86_64,
 									  cfgopts.cov, cfgopts.doDocComments, cfgopts.noboundscheck,
 									  cfgopts.compiler == Compiler.GDC,
@@ -882,6 +883,10 @@ class LanguageService : DisposingComObject,
 
 			versionids = tokenizeArgs(cfgopts.versionids);
 			debugids = tokenizeArgs(cfgopts.debugids);
+		}
+		else
+		{
+			imp = Package.GetGlobalOptions().getImportPaths(Compiler.DMD);
 		}
 		vdServerClient.ConfigureSemanticProject(file, assumeUnique(imp), assumeUnique(stringImp), assumeUnique(versionids), assumeUnique(debugids), flags);
 	}

--- a/visuald/dlangsvc.d
+++ b/visuald/dlangsvc.d
@@ -2943,7 +2943,7 @@ else
 		else if(startTok != "{" && startTok != "[" && hasOpenBrace)
 			indent = langPrefs.uTabSize;
 		if(prevTok == "{" || prevTok == "[")
-			return countVisualSpaces(lntokIt.lineText, langPrefs.uTabSize) + langPrefs.uTabSize + labelIndent;
+			return nextTabPosition(countVisualSpaces(lntokIt.lineText, langPrefs.uTabSize) + labelIndent, langPrefs.uTabSize);
 
 		bool skipLabel = false;
 		do
@@ -2952,7 +2952,7 @@ else
 			if(txt == "(")
 				return visiblePosition(lntokIt.lineText, langPrefs.uTabSize, lntokIt.getIndex() + 1);
 			if(isOpenBraceOrCase(lntokIt))
-				return countVisualSpaces(lntokIt.lineText, langPrefs.uTabSize) + langPrefs.uTabSize + indent + labelIndent;
+				return nextTabPosition(countVisualSpaces(lntokIt.lineText, langPrefs.uTabSize) + indent + labelIndent, langPrefs.uTabSize);
 
 			if(txt == "}" || txt == ";") // triggers the end of a statement, but not do {} while()
 			{
@@ -2973,7 +2973,7 @@ else
 			{
 				findMatchingIf();
 				if(isOpenBraceOrCase(lntokIt))
-					return countVisualSpaces(lntokIt.lineText, langPrefs.uTabSize) + langPrefs.uTabSize + labelIndent;
+					return nextTabPosition(countVisualSpaces(lntokIt.lineText, langPrefs.uTabSize) + labelIndent, + langPrefs.uTabSize);
 			}
 		}
 		while(lntokIt.retreatOverBraces());

--- a/visuald/dllmain.d
+++ b/visuald/dllmain.d
@@ -159,24 +159,22 @@ void RunDLLUnregisterUser(HWND hwnd, HINSTANCE hinst, LPSTR lpszCmdLine, int nCm
 }
 
 extern(Windows)
-void VerifyMSObj(HWND hwnd, HINSTANCE hinst, LPSTR lpszCmdLine, int nCmdShow)
+void VerifyMSObjW(HWND hwnd, HINSTANCE hinst, LPWSTR lpszCmdLine, int nCmdShow)
 {
 	wstring ws = to_wstring(lpszCmdLine);
 	VerifyMSObjectParser(ws);
 }
 
 extern(Windows)
-void WritePackageDef(HWND hwnd, HINSTANCE hinst, LPSTR lpszCmdLine, int nCmdShow)
+void WritePackageDefW(HWND hwnd, HINSTANCE hinst, LPWSTR lpszCmdLine, int nCmdShow)
 {
-	wstring ws = to_wstring(lpszCmdLine) ~ cast(wchar)0;
-	WriteExtensionPackageDefinition(ws.ptr);
+	WriteExtensionPackageDefinition(lpszCmdLine);
 }
 
 extern(Windows)
-void GenerateGeneralXML(HWND hwnd, HINSTANCE hinst, LPSTR lpszCmdLine, int nCmdShow)
+void GenerateGeneralXMLW(HWND hwnd, HINSTANCE hinst, LPWSTR lpszCmdLine, int nCmdShow)
 {
-	import std.windows.charset;
-	string cmdline = fromMBSz(cast(immutable)lpszCmdLine);
+	string cmdline = to_string(lpszCmdLine);
 	string[] args = split(cmdline, ';');
 	if (args.length == 3)
 		generateGeneralXML(args[0], args[1], args[2]);

--- a/visuald/dpackage.d
+++ b/visuald/dpackage.d
@@ -1289,6 +1289,8 @@ class GlobalOptions
 	bool lastColorizeVersions;
 	bool lastUseDParser;
 
+	bool isVS2017; // VS 2017
+
 	this()
 	{
 	}
@@ -1426,7 +1428,10 @@ class GlobalOptions
 				string ver = strip(readUtf8(defverFile));
 				VCInstallDir = VSInstallDir ~ r"VC\";
 				if (!ver.empty)
+				{
 					VCToolsInstallDir = VCInstallDir ~ r"Tools\MSVC\" ~ ver ~ r"\";
+					isVS2017 = true;
+				}
 			}
 			catch(Exception)
 			{

--- a/visuald/dpackage.d
+++ b/visuald/dpackage.d
@@ -1466,6 +1466,8 @@ class GlobalOptions
 			dir = (expand ? VCInstallDir : "$(VCINSTALLDIR)");
 			if (sub.startsWith("lib") && x64)
 				sub = "lib\\amd64" ~ sub[3 .. $];
+			else if (sub == "bin" && x64)
+				sub = "bin\\amd64";
 		}
 		return dir ~ sub;
 	}

--- a/visuald/dpackage.d
+++ b/visuald/dpackage.d
@@ -1574,7 +1574,7 @@ class GlobalOptions
 
 			string getDefaultLibPathCOFF64()
 			{
-				string libpath = getVCDir ("lib", true);
+				string libpath = getVCDir("lib", true);
 				string dir = replaceGlobalMacros(libpath);
 				if(std.file.exists(dir ~ "\\legacy_stdio_definitions.lib"))
 					libpath ~= "\n$(UCRTSdkDir)Lib\\$(UCRTVersion)\\ucrt\\x64";
@@ -1593,7 +1593,7 @@ class GlobalOptions
 
 			string getDefaultLibPathCOFF32()
 			{
-				string libpath = getVCDir ("lib", false);
+				string libpath = getVCDir("lib", false);
 				string dir = replaceGlobalMacros(libpath);
 				if(std.file.exists(dir ~ "\\legacy_stdio_definitions.lib"))
 					libpath ~= "\n$(UCRTSdkDir)Lib\\$(UCRTVersion)\\ucrt\\x86";
@@ -1653,8 +1653,10 @@ class GlobalOptions
 			DMD.ExeSearchPath32coff = DMD.ExeSearchPath;
 			GDC.ExeSearchPath       = r"$(GDCInstallDir)bin;$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir;
 			GDC.ExeSearchPath64     = GDC.ExeSearchPath;
-			LDC.ExeSearchPath       = r"$(LDCInstallDir)bin;" ~ getVCDir("bin", false) ~ r";$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir;
-			LDC.ExeSearchPath64     = r"$(LDCInstallDir)bin;" ~ getVCDir("bin", true)  ~ r";$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir;
+			// LDC can call the linker itself, tracking only works if ldc2.exe and link.exe have the same architecture
+			bool ldcX64 = true;
+			LDC.ExeSearchPath       = r"$(LDCInstallDir)bin;" ~ getVCDir("bin", ldcX64) ~ r";$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir;
+			LDC.ExeSearchPath64     = r"$(LDCInstallDir)bin;" ~ getVCDir("bin", ldcX64) ~ r";$(VSINSTALLDIR)Common7\IDE;" ~ sdkBinDir;
 
 			DMD.LibSearchPath64     = getDefaultLibPathCOFF64();
 			LDC.LibSearchPath64     = DMD.LibSearchPath64;

--- a/visuald/hierutil.d
+++ b/visuald/hierutil.d
@@ -1012,8 +1012,12 @@ string[] GetImportPaths(string file)
 	{
 		scope(exit) release(cfg);
 		imports = GetImportPaths(cfg);
+		imports ~= Package.GetGlobalOptions().getImportPaths(cfg.GetProjectOptions().compiler);
 	}
-	imports ~= Package.GetGlobalOptions().getImportPaths();
+	else
+	{
+		imports ~= Package.GetGlobalOptions().getImportPaths(Compiler.DMD);
+	}
 	return imports;
 }
 

--- a/visuald/propertypage.d
+++ b/visuald/propertypage.d
@@ -1541,7 +1541,7 @@ class DmdEventsPropertyPage : ProjectPropertyPage
 		AddControl("Pre-Build Command", mPreCmd = new MultiLineText(mCanvas), 500);
 		AddControl("Post-Build Command", mPostCmd = new MultiLineText(mCanvas), 500);
 
-		Label lab = new Label(mCanvas, "Use \"if errorlevel 1 goto reportError\" to cancel on error");
+		Label lab = new Label(mCanvas, "Use \"if %errorlevel% neq 0 goto reportError\" to cancel on error");
 		lab.setRect(0, mLineY, getWidgetWidth(mCanvas, kPageWidth), kLineHeight);
 		addResizableWidget(lab, kAttachBottom);
 	}

--- a/visuald/propertypage.d
+++ b/visuald/propertypage.d
@@ -1469,9 +1469,6 @@ class DmdLinkerPropertyPage : ProjectPropertyPage
 		AddControl("Definition File", mDefFile = new Text(mCanvas), btn);
 		btn = new Button(mCanvas, "...", ID_RESFILE);
 		AddControl("Resource File",   mResFile = new Text(mCanvas), btn);
-		AddControl("Generate Map File", mGenMap = new ComboBox(mCanvas,
-			[ "Minimum", "Symbols By Address", "Standard", "Full", "With cross references" ], false));
-		AddControl("", mImplib = new CheckBox(mCanvas, "Create import library"));
 		AddControl("", mPrivatePhobos = new CheckBox(mCanvas, "Build and use local version of phobos with same compiler options"));
 		AddControl("", mUseStdLibPath = new CheckBox(mCanvas, "Use global and standard library search paths"));
 		AddControl("C Runtime", mCRuntime = new ComboBox(mCanvas, [ "None", "Static Release (LIBCMT)", "Static Debug (LIBCMTD)", "Dynamic Release (MSCVRT)", "Dynamic Debug (MSCVRTD)" ], false));
@@ -1491,8 +1488,6 @@ class DmdLinkerPropertyPage : ProjectPropertyPage
 		mLibPaths.setText(options.libpaths);
 		mDefFile.setText(options.deffile);
 		mResFile.setText(options.resfile);
-		mGenMap.setSelection(options.mapverbosity);
-		mImplib.setChecked(options.createImplib);
 		mUseStdLibPath.setChecked(options.useStdLibPath);
 		mPrivatePhobos.setChecked(options.privatePhobos);
 		mCRuntime.setSelection(options.cRuntime);
@@ -1509,8 +1504,6 @@ class DmdLinkerPropertyPage : ProjectPropertyPage
 		changes += changeOption(mLibPaths.getText(), options.libpaths, refoptions.libpaths);
 		changes += changeOption(mDefFile.getText(), options.deffile, refoptions.deffile);
 		changes += changeOption(mResFile.getText(), options.resfile, refoptions.resfile);
-		changes += changeOption(cast(uint) mGenMap.getSelection(), options.mapverbosity, refoptions.mapverbosity);
-		changes += changeOption(mImplib.isChecked(), options.createImplib, refoptions.createImplib);
 		changes += changeOption(mUseStdLibPath.isChecked(), options.useStdLibPath, refoptions.useStdLibPath);
 		changes += changeOption(mPrivatePhobos.isChecked(), options.privatePhobos, refoptions.privatePhobos);
 		changes += changeOption(cast(uint) mCRuntime.getSelection(), options.cRuntime, refoptions.cRuntime);
@@ -1523,11 +1516,107 @@ class DmdLinkerPropertyPage : ProjectPropertyPage
 	Text mLibPaths;
 	Text mDefFile;
 	Text mResFile;
-	ComboBox mGenMap;
-	CheckBox mImplib;
 	CheckBox mUseStdLibPath;
 	CheckBox mPrivatePhobos;
 	ComboBox mCRuntime;
+}
+
+class LinkerOutputPropertyPage : ProjectPropertyPage
+{
+	override string GetCategoryName() { return "Linker"; }
+	override string GetPageName() { return "Output Files"; }
+
+	this()
+	{
+	}
+
+	override void UpdateDirty(bool bDirty)
+	{
+		super.UpdateDirty(bDirty);
+		EnableControls();
+	}
+
+	enum ID_PDBFILE = 1055;
+	enum ID_IMPFILE = 1056;
+	enum ID_EXPFILE = 1057;
+	enum ID_MAPFILE = 1058;
+
+	extern(D) override void OnCommand(Widget w, int cmd)
+	{
+		switch(cmd)
+		{
+			case ID_PDBFILE:
+				if(auto file = browseSaveFile(mCanvas.hwnd, "Select PDB file", "PDB files\0*.pdb\0All Files\0*.*\0", GetProjectDir()))
+					mPDBFile.setText(makeRelative(file, GetProjectDir()));
+				break;
+			case ID_IMPFILE:
+				if(auto file = browseSaveFile(mCanvas.hwnd, "Select import library file", "Import library files\0*.lib\0All Files\0*.*\0", GetProjectDir()))
+					mImpFile.setText(makeRelative(file, GetProjectDir()));
+				break;
+			case ID_MAPFILE:
+				if(auto file = browseSaveFile(mCanvas.hwnd, "Select map file", "Map files\0*.map\0All Files\0*.*\0", GetProjectDir()))
+					mMapFile.setText(makeRelative(file, GetProjectDir()));
+				break;
+			default:
+				break;
+		}
+		super.OnCommand(w, cmd);
+	}
+
+	override void CreateControls()
+	{
+		AddControl("Generate Map File",
+				   mGenMap = new ComboBox(mCanvas, [ "None", "Symbols By Address", "Standard",
+				                                     "Full", "With cross references" ], false));
+		auto btn = new Button(mCanvas, "+", ID_MAPFILE);
+		AddControl("Map File", mMapFile = new Text(mCanvas), btn);
+		btn = new Button(mCanvas, "+", ID_IMPFILE);
+		AddControl("", mImplib = new CheckBox(mCanvas, "Create import library"));
+		AddControl("Import Library", mImpFile = new Text(mCanvas), btn);
+		btn = new Button(mCanvas, "+", ID_PDBFILE);
+		AddControl("PDB File", mPDBFile = new Text(mCanvas), btn);
+	}
+
+	void EnableControls()
+	{
+		if(ProjectOptions options = GetProjectOptions())
+		{
+			bool staticLib = options.lib == OutputType.StaticLib;
+			mPDBFile.setEnabled(!staticLib);
+			mImpFile.setEnabled(!staticLib);
+			mMapFile.setEnabled(!staticLib);
+			mGenMap.setEnabled(!staticLib);
+			mImplib.setEnabled(!staticLib);
+		}
+	}
+
+	override void SetControls(ProjectOptions options)
+	{
+		mPDBFile.setText(options.pdbfile);
+		mImpFile.setText(options.impfile);
+		mMapFile.setText(options.mapfile);
+		mGenMap.setSelection(options.mapverbosity);
+		mImplib.setChecked(options.createImplib);
+
+		EnableControls();
+	}
+
+	override int DoApply(ProjectOptions options, ProjectOptions refoptions)
+	{
+		int changes = 0;
+		changes += changeOption(mPDBFile.getText(), options.pdbfile, refoptions.pdbfile);
+		changes += changeOption(mImpFile.getText(), options.impfile, refoptions.impfile);
+		changes += changeOption(mMapFile.getText(), options.mapfile, refoptions.mapfile);
+		changes += changeOption(cast(uint) mGenMap.getSelection(), options.mapverbosity, refoptions.mapverbosity);
+		changes += changeOption(mImplib.isChecked(), options.createImplib, refoptions.createImplib);
+		return changes;
+	}
+
+	Text mPDBFile;
+	Text mImpFile;
+	Text mMapFile;
+	ComboBox mGenMap;
+	CheckBox mImplib;
 }
 
 class DmdEventsPropertyPage : ProjectPropertyPage
@@ -2439,6 +2528,7 @@ const GUID    g_DebuggingPropertyPage    = uuid("002a2de9-8bb6-484d-9819-7e4ad40
 const GUID    g_FilePropertyPage         = uuid("002a2de9-8bb6-484d-981a-7e4ad4084715");
 const GUID    g_DmdDocPropertyPage       = uuid("002a2de9-8bb6-484d-981b-7e4ad4084715");
 const GUID    g_DmdCmdLinePropertyPage   = uuid("002a2de9-8bb6-484d-981c-7e4ad4084715");
+const GUID    g_LinkerOutputPropertyPage = uuid("002a2de9-8bb6-484d-981d-7e4ad4084715");
 
 // does not need to be registered, created explicitely by package
 const GUID    g_DmdDirPropertyPage       = uuid("002a2de9-8bb6-484d-9820-7e4ad4084715");
@@ -2466,6 +2556,7 @@ const GUID*[] guids_propertyPages =
 	&g_FilePropertyPage,
 	&g_DmdDocPropertyPage,
 	&g_DmdCmdLinePropertyPage,
+	&g_LinkerOutputPropertyPage,
 ];
 
 class PropertyPageFactory : DComObject, IClassFactory
@@ -2513,6 +2604,8 @@ class PropertyPageFactory : DComObject, IClassFactory
 			ppp = newCom!DmdOutputPropertyPage();
 		else if(mClsid == g_DmdLinkerPropertyPage)
 			ppp = newCom!DmdLinkerPropertyPage();
+		else if(mClsid == g_LinkerOutputPropertyPage)
+			ppp = newCom!LinkerOutputPropertyPage();
 		else if(mClsid == g_DmdEventsPropertyPage)
 			ppp = newCom!DmdEventsPropertyPage();
 		else if(mClsid == g_DmdCmdLinePropertyPage)
@@ -2535,7 +2628,7 @@ class PropertyPageFactory : DComObject, IClassFactory
 	static int GetProjectPages(CAUUID *pPages, bool addFile)
 	{
 version(all) {
-		pPages.cElems = (addFile ? 12 : 11);
+		pPages.cElems = (addFile ? 13 : 12);
 		pPages.pElems = cast(GUID*)CoTaskMemAlloc(pPages.cElems*GUID.sizeof);
 		if (!pPages.pElems)
 			return E_OUTOFMEMORY;
@@ -2552,6 +2645,7 @@ version(all) {
 		pPages.pElems[idx++] = g_DmdDocPropertyPage;
 		pPages.pElems[idx++] = g_DmdOutputPropertyPage;
 		pPages.pElems[idx++] = g_DmdLinkerPropertyPage;
+		pPages.pElems[idx++] = g_LinkerOutputPropertyPage;
 		pPages.pElems[idx++] = g_DmdCmdLinePropertyPage;
 		pPages.pElems[idx++] = g_DmdEventsPropertyPage;
 		return S_OK;

--- a/visuald/propertypage.d
+++ b/visuald/propertypage.d
@@ -1469,7 +1469,8 @@ class DmdLinkerPropertyPage : ProjectPropertyPage
 		AddControl("Definition File", mDefFile = new Text(mCanvas), btn);
 		btn = new Button(mCanvas, "...", ID_RESFILE);
 		AddControl("Resource File",   mResFile = new Text(mCanvas), btn);
-		AddControl("", mPrivatePhobos = new CheckBox(mCanvas, "Build and use local version of phobos with same compiler options"));
+		AddControl("", mPrivatePhobos = new CheckBox(mCanvas, "Build and use local version of phobos with same compiler options (DMD only)"));
+		AddControl("", mDebugLib      = new CheckBox(mCanvas, "Use debug version of the D runtime library (LDC only)"));
 		AddControl("", mUseStdLibPath = new CheckBox(mCanvas, "Use global and standard library search paths"));
 		AddControl("C Runtime", mCRuntime = new ComboBox(mCanvas, [ "None", "Static Release (LIBCMT)", "Static Debug (LIBCMTD)", "Dynamic Release (MSCVRT)", "Dynamic Debug (MSCVRTD)" ], false));
 	}
@@ -1477,7 +1478,11 @@ class DmdLinkerPropertyPage : ProjectPropertyPage
 	void EnableControls()
 	{
 		if(ProjectOptions options = GetProjectOptions())
+		{
+			mPrivatePhobos.setEnabled(options.compiler == Compiler.DMD);
+			mDebugLib.setEnabled(options.compiler == Compiler.LDC);
 			mCRuntime.setEnabled(options.isX86_64 || options.mscoff);
+		}
 	}
 
 	override void SetControls(ProjectOptions options)
@@ -1490,6 +1495,7 @@ class DmdLinkerPropertyPage : ProjectPropertyPage
 		mResFile.setText(options.resfile);
 		mUseStdLibPath.setChecked(options.useStdLibPath);
 		mPrivatePhobos.setChecked(options.privatePhobos);
+		mDebugLib.setChecked(options.debuglib);
 		mCRuntime.setSelection(options.cRuntime);
 
 		EnableControls();
@@ -1506,6 +1512,7 @@ class DmdLinkerPropertyPage : ProjectPropertyPage
 		changes += changeOption(mResFile.getText(), options.resfile, refoptions.resfile);
 		changes += changeOption(mUseStdLibPath.isChecked(), options.useStdLibPath, refoptions.useStdLibPath);
 		changes += changeOption(mPrivatePhobos.isChecked(), options.privatePhobos, refoptions.privatePhobos);
+		changes += changeOption(mDebugLib.isChecked(), options.debuglib, refoptions.debuglib);
 		changes += changeOption(cast(uint) mCRuntime.getSelection(), options.cRuntime, refoptions.cRuntime);
 		return changes;
 	}
@@ -1518,6 +1525,7 @@ class DmdLinkerPropertyPage : ProjectPropertyPage
 	Text mResFile;
 	CheckBox mUseStdLibPath;
 	CheckBox mPrivatePhobos;
+	CheckBox mDebugLib;
 	ComboBox mCRuntime;
 }
 

--- a/visuald/viewfilter.d
+++ b/visuald/viewfilter.d
@@ -602,7 +602,7 @@ version(tip)
 		string cmd = cfg.GetCompileCommand(pFile, !dbg && !run && !disasm, stool, addopt);
 		if(cmd.length)
 		{
-			cmd ~= "if not errorlevel 1 echo Compilation successful.\n";
+			cmd ~= "if %errorlevel% == 0 echo Compilation successful.\n";
 			string workdir = cfg.GetProjectDir();
 			string outfile = cfg.GetOutputFile(pFile, stool);
 			outfile = makeFilenameAbsolute(outfile, workdir);
@@ -613,17 +613,17 @@ version(tip)
 			{
 				string asmfile = outfile ~ ".asm";
 				string linfile = outfile ~ ".lines";
-				cmd ~= "if errorlevel 1 exit %ERRORLEVEL% /B\n";
+				cmd ~= "if %errorlevel% neq 0 exit %ERRORLEVEL% /B\n";
 				cmd ~= "echo Dumping disassembly\n";
 				cmd ~= cfg.GetDisasmCommand(outfile, asmfile) ~ "\n";
-				cmd ~= "if errorlevel 1 exit %ERRORLEVEL% /B\n";
+				cmd ~= "if %errorlevel% neq 0 exit %ERRORLEVEL% /B\n";
 				cmd ~= "echo Dumping line numbers\n";
 				cmd ~= "\"" ~ Package.GetGlobalOptions().VisualDInstallDir ~ "cv2pdb\\dumplines.exe\" " ~ quoteFilename(outfile)
 					~ " > " ~ quoteFilename(linfile) ~ "\n";
 			}
 			if(run)
 			{
-				cmd ~= "if errorlevel 1 exit %ERRORLEVEL% /B\n";
+				cmd ~= "if %errorlevel% neq 0 exit %ERRORLEVEL% /B\n";
 				cmd ~= quoteFilename(outfile) ~ "\n";
 				cmd ~= "echo Execution result code: %ERRORLEVEL%\n";
 			}

--- a/visuald/visuald.def
+++ b/visuald/visuald.def
@@ -19,7 +19,7 @@ EXPORTS
 	RunDLLUnregister           = RunDLLUnregister           PRIVATE
 	RunDLLRegisterUser         = RunDLLRegisterUser         PRIVATE
 	RunDLLUnregisterUser       = RunDLLUnregisterUser       PRIVATE
-	VerifyMSObj                = VerifyMSObj                PRIVATE
-	WritePackageDef            = WritePackageDef            PRIVATE
+	VerifyMSObjW               = VerifyMSObjW               PRIVATE
+	WritePackageDefW           = WritePackageDefW           PRIVATE
 	GetCoverageData            = GetCoverageData            PRIVATE
-	GenerateGeneralXML         = GenerateGeneralXML         PRIVATE
+	GenerateGeneralXMLW        = GenerateGeneralXMLW        PRIVATE

--- a/visuald/visuald.visualdproj
+++ b/visuald/visuald.visualdproj
@@ -760,7 +760,7 @@
    <File path="Resources\faninout.ico" />
    <File path="Resources\GroupByType.ico" />
    <File path="Resources\pkgcmd.vsct" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
-if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; 
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 
 set VSSDKInstall=%VSSDK150Install%
@@ -773,6 +773,8 @@ if &quot;%VSSDKInstall%&quot; == &quot;&quot; set VSSDKInstall=c:\l\vs12SDK
 set VSCT=%VSSDKInstall%\VisualStudioIntegration\Tools\Bin\VSCT.exe
 if not exist &quot;%VSCT%&quot; goto no_VSCT
 &quot;%VSCT%&quot; $(InputPath) $(InputDir)\$(InputName).cto -I&quot;%VSSDKInstall%\VisualStudioIntegration\Common\Inc&quot;
+rem workaround for VS2017 15.3.1: VSCT.exe broken, use existing cto file
+rem if exist $(InputDir)\$(InputName).cto exit /B 0
 goto reportError
 
 :no_VSCT
@@ -787,7 +789,7 @@ echo It is part of the VS2010-VS2013 SDK and is needed to compile $(InputPath)
    <File path="Resources\SearchSymbol.ico" />
    <File path="Resources\settrace.ico" />
    <File path="visuald.rc" customcmd="if exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
-if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; 
+if exist &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; ( pushd . &amp;&amp; call &quot;$(VCINSTALLDIR)\Auxiliary\Build\vcvars32.bat&quot; &amp;&amp; popd )
 if errorlevel 1 goto reportError
 rc /fo&quot;$(OutDir)\visuald.res&quot; $(InputPath)" tool="Custom" dependencies="resources\pkgcmd.cto;resources\daboutlogo.ico;..\version;resources\dimagelist.bmp;resources\completionset.bmp" linkoutput="true" outfile="$(OutDir)\visuald.res" />
    <File path="Resources\WholeWord.ico" />

--- a/visuald/visuald.visualdproj
+++ b/visuald/visuald.visualdproj
@@ -57,7 +57,7 @@
   <imppath>..</imppath>
   <fileImppath>..;resources</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -160,7 +160,7 @@
   <imppath>..</imppath>
   <fileImppath>..;resources</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -263,7 +263,7 @@
   <imppath>..;m:\s\d\rainers\druntime\src</imppath>
   <fileImppath>..;resources</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>1</doDocComments>
@@ -366,7 +366,7 @@
   <imppath>..</imppath>
   <fileImppath>..;resources</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>1</doDocComments>
@@ -469,7 +469,7 @@
   <imppath>..</imppath>
   <fileImppath>..;resources</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>0</doDocComments>
@@ -572,7 +572,7 @@
   <imppath>..</imppath>
   <fileImppath>..;resources</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>1</doDocComments>
@@ -675,7 +675,7 @@
   <imppath>..</imppath>
   <fileImppath>..;resources</fileImppath>
   <outdir>..\bin\$(ConfigurationName)</outdir>
-  <objdir>$(OutDir)\obj</objdir>
+  <objdir>$(OutDir)\$(ProjectName)</objdir>
   <objname />
   <libname />
   <doDocComments>1</doDocComments>

--- a/visuald/visuald.visualdproj
+++ b/visuald/visuald.visualdproj
@@ -75,7 +75,7 @@
   <versionlevel>0</versionlevel>
   <versionids />
   <dump_source>0</dump_source>
-  <mapverbosity>3</mapverbosity>
+  <mapverbosity>0</mapverbosity>
   <createImplib>0</createImplib>
   <defaultlibname />
   <debuglibname />
@@ -95,6 +95,9 @@
   <deffile />
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).dll</exefile>
+  <pdbfile>$(IntDir)\$(SafeProjectName).pdb</pdbfile>
+  <impfile>$(IntDir)\$(SafeProjectName).lib</impfile>
+  <mapfile>$(IntDir)\$(SafeProjectName).map</mapfile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>1</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -178,7 +181,7 @@
   <versionlevel>0</versionlevel>
   <versionids />
   <dump_source>0</dump_source>
-  <mapverbosity>1</mapverbosity>
+  <mapverbosity>0</mapverbosity>
   <createImplib>0</createImplib>
   <defaultlibname />
   <debuglibname />
@@ -198,6 +201,9 @@
   <deffile />
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).dll</exefile>
+  <pdbfile>$(IntDir)\$(SafeProjectName).pdb</pdbfile>
+  <impfile>$(IntDir)\$(SafeProjectName).lib</impfile>
+  <mapfile>$(IntDir)\$(SafeProjectName).map</mapfile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>1</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -281,7 +287,7 @@
   <versionlevel>0</versionlevel>
   <versionids>TESTMAIN$(TEST_OPTIONS)</versionids>
   <dump_source>0</dump_source>
-  <mapverbosity>3</mapverbosity>
+  <mapverbosity>0</mapverbosity>
   <createImplib>0</createImplib>
   <defaultlibname />
   <debuglibname />
@@ -301,6 +307,9 @@
   <deffile />
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).exe</exefile>
+  <pdbfile>$(IntDir)\$(SafeProjectName).pdb</pdbfile>
+  <impfile>$(IntDir)\$(SafeProjectName).lib</impfile>
+  <mapfile>$(IntDir)\$(SafeProjectName).map</mapfile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>1</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -404,6 +413,9 @@
   <deffile />
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).dll</exefile>
+  <pdbfile>$(IntDir)\$(SafeProjectName).pdb</pdbfile>
+  <impfile>$(IntDir)\$(SafeProjectName).lib</impfile>
+  <mapfile>$(IntDir)\$(SafeProjectName).map</mapfile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>1</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -507,6 +519,9 @@
   <deffile />
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).dll</exefile>
+  <pdbfile>$(IntDir)\$(SafeProjectName).pdb</pdbfile>
+  <impfile>$(IntDir)\$(SafeProjectName).lib</impfile>
+  <mapfile>$(IntDir)\$(SafeProjectName).map</mapfile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>1</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -590,7 +605,7 @@
   <versionlevel>0</versionlevel>
   <versionids />
   <dump_source>0</dump_source>
-  <mapverbosity>3</mapverbosity>
+  <mapverbosity>0</mapverbosity>
   <createImplib>0</createImplib>
   <defaultlibname />
   <debuglibname />
@@ -610,6 +625,9 @@
   <deffile />
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).dll</exefile>
+  <pdbfile>$(IntDir)\$(SafeProjectName).pdb</pdbfile>
+  <impfile>$(IntDir)\$(SafeProjectName).lib</impfile>
+  <mapfile>$(IntDir)\$(SafeProjectName).map</mapfile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>2</cRuntime>
   <privatePhobos>0</privatePhobos>
@@ -693,7 +711,7 @@
   <versionlevel>0</versionlevel>
   <versionids />
   <dump_source>0</dump_source>
-  <mapverbosity>3</mapverbosity>
+  <mapverbosity>0</mapverbosity>
   <createImplib>0</createImplib>
   <defaultlibname />
   <debuglibname />
@@ -713,6 +731,9 @@
   <deffile />
   <resfile />
   <exefile>$(OutDir)\$(ProjectName).dll</exefile>
+  <pdbfile>$(IntDir)\$(SafeProjectName).pdb</pdbfile>
+  <impfile>$(IntDir)\$(SafeProjectName).lib</impfile>
+  <mapfile>$(IntDir)\$(SafeProjectName).map</mapfile>
   <useStdLibPath>1</useStdLibPath>
   <cRuntime>1</cRuntime>
   <privatePhobos>0</privatePhobos>


### PR DESCRIPTION
  * cv2pdb
    - now also search VS2017 registry entries to find mspdb140.dll
    - fix working with the VS2017 update 15.3.1
  * improve handling of non-ASCII installation paths:
    - use unicode aware version of NSIS, register through wide string API of rundll32
    - parse sc.ini with current code page
    - pipedmd: pass wide string command line to sub process
    - convert MS linker response file to UTF16
  * build system
    - add workaround for broken TLS when linking with link.exe from VS2017 update 15.3.1
    - build single object file to intermediate directory rather than output folder
    - intermediate executable for cv2pdb now written to intermediate directory
    - custom build batch files now written to intermediate directory
    - use "if %errorlevel% neq 0" instead of "if errorlevel 1" in batches to capture crashes, too
    - fix default executable search path for LDC assuming a 64-bit compiler executable (avoids 
      linker error -1073741701)
    - added *.tlog to default files to clean
    - add import library to project outputs if "create import library" enabled
    - added linker options to configure map file, import library and PDB file
    - LDC: add option to link against debug runtime library
    - LDC: no longer trIES to run cv2pdb
  * dparser:
    - when building with LDC, use import path from its config file instead of DMDs' sc.ini
    - parse "static foreach" (but no semantic analysis)
  * fixed spurious freeze in precise GC (mostly during startup)
  * indentation of lambdas as parameter arguments now aligns statements on tab stops
