### PR TITLE
Visual D 0.48.0-beta2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -989,12 +989,14 @@ Version history
 unreleased Version 0.48.0
 
   * installation
+    - installer and binaries now digitally signed by the "D Language Foundation"
     - fixed uninstallation for VS2017
     - installation for VS2013+ now uses PackageManifest format instead of Vsix
     - VS2017: loading the Visual D package could crash with some VS installation "ids""
     - avoid initial error message regarding altered assemblies with same version
     - fix installation of the D icon for the solution explorer in VS2017
     - installer hides options for VS2005-VS2012 if not installed
+    - remove old extension folders before installation
   * new project wizard
     - restore project templates for VS2008, new project wizard doesn't work there'
     - mixed D/C++ VC project: optionally adding main in C++, setup precompiled headers
@@ -1005,18 +1007,21 @@ unreleased Version 0.48.0
     - VS2017: D compiler installation paths and "demangle link errors" are now saved 
 	  to "HKCR\Softwre\Visual D" to be picked up by msbuild
     - show detected compiler version below installation path
-	- removed option "parse source for syntax errors", now always on
-	- removed option "expansions from text buffer", now always off
-	- removed option "use semantic analysis for goto definition", now always on
-	- removed option "override linker settings from sc.ini", always on as linker no 
-	  longer set in sc.ini since dmd 2.079
-	- removed option "additional linker options", it was invisible anyway
-	- rearrange settings to better show their scope
+    - removed option "parse source for syntax errors", now always on
+    - removed option "expansions from text buffer", now always off
+    - removed option "use semantic analysis for goto definition", now always on
+    - removed option "override linker settings from sc.ini", always on as linker no 
+      longer set in sc.ini since dmd 2.079
+    - removed option "additional linker options", it was invisible anyway
+    - rearrange settings to better show their scope
   * dparser
     - semantic analysis did not work if "parse source for syntax errors" was disabled
     - no semantic info for a package if any file in the package has fatal parser error
     - now has semantic support for static foreach (thanks to Alexander Bothe)
     - fixed "Find references"
+    - added experimental option to show value of constants in tooltip
+    - the last user specified version was prepended to "Windows"
+    - predefined versions now evaluated by compiler invocation
   * mago
     - added option to show base class fields as direct fields
     - allow suffix 'h' for hex numbers for better interoperablility with VS disassembly
@@ -1027,7 +1032,7 @@ unreleased Version 0.48.0
     - engine: Fix the way the debugger steps over instructions with REP prefix.
   * cv2pdb
     - can now detect VS2017 via Setup-COM-API
-	- some DWARF fixes
+    - some DWARF fixes
   * when pasting code to D source file newlines are adapted to surrounding code
   * fixed "Compile and Run" on selection
   * fix help via F1 for dmd 2.072+

--- a/CHANGES
+++ b/CHANGES
@@ -1030,6 +1030,7 @@ unreleased Version 0.48.0
     - concord: fix crash when showing children in data tooltip (mostly occured in VS2017)
     - concord: allow dragging addresses to the disassembly window
     - engine: Fix the way the debugger steps over instructions with REP prefix.
+    - engine: the disassemble view now supports SSE4 and AVX
   * cv2pdb
     - can now detect VS2017 via Setup-COM-API
     - some DWARF fixes

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,9 @@ $(DCXXFILT_EXE): tools\dcxxfilt.d
 ##################################
 # create installer
 
-install_vs: install_modules dparser cv2pdb mago dbuild12 dbuild14 dbuild15 install_only
+install_release_modules: install_modules dparser cv2pdb mago dbuild12 dbuild14 dbuild15
+
+install_vs: install_release_modules install_only
 
 install_vs_no_vs2017:   install_modules fake_dparser cv2pdb mago dbuild12 dbuild14 fake_dbuild15 install_only
 

--- a/VERSION
+++ b/VERSION
@@ -2,4 +2,4 @@
 #define VERSION_MINOR      48
 #define VERSION_REVISION   0
 #define VERSION_BETA       -beta
-#define VERSION_BUILD      1
+#define VERSION_BUILD      2

--- a/build/dte_idl.bat
+++ b/build/dte_idl.bat
@@ -20,8 +20,9 @@ set MSENV=%COMMONPROGRAMFILES%\Microsoft Shared\MSEnv
 if not exist "%MSENV%\dte80.olb" (echo "%MSENV%\dte80.olb" does not exist && exit /B 1)
 
 set IVIEWER=
-if "%IVIEWER%" == "" if exist "%WindowsSdkDir%\bin\x86\iviewers.dll" set IVIEWER=%WindowsSdkDir%\bin\x86\iviewers.dll
-if "%IVIEWER%" == "" if exist "%WindowsSdkDir%\bin\iviewers.dll"     set IVIEWER=%WindowsSdkDir%\bin\iviewers.dll
+if "%IVIEWER%" == "" if exist "%WindowsSdkVerBinPath%\x86\iviewers.dll" set IVIEWER=%WindowsSdkVerBinPath%\x86\iviewers.dll
+if "%IVIEWER%" == "" if exist "%WindowsSdkDir%\bin\x86\iviewers.dll"    set IVIEWER=%WindowsSdkDir%\bin\x86\iviewers.dll
+if "%IVIEWER%" == "" if exist "%WindowsSdkDir%\bin\iviewers.dll"        set IVIEWER=%WindowsSdkDir%\bin\iviewers.dll
 if "%IVIEWER%" == "" (echo "iviewer.dll" not found && exit /B 1)
 
 echo "%TLB2IDL%" "%MSENV%\dte80.olb" "%DTE_IDL_PATH%\dte80.idl" "%IVIEWER%"

--- a/c2d/cpp2d_main.d
+++ b/c2d/cpp2d_main.d
@@ -823,7 +823,7 @@ unittest
 }
 
 ///////////////////////////////////////////////////////////////
-version(Win32) // different mangling for Win64
+version(none) // different mangling for Win64
 {
 extern extern(C) __gshared ModuleInfo D4core3sys7windows10stacktrace12__ModuleInfoZ;
 

--- a/c2d/idl2d.d
+++ b/c2d/idl2d.d
@@ -2770,7 +2770,7 @@ struct tagSIZE
     LONG        cx;
     LONG        cy;
 }
-alias tagSIZE SIZE; alias tagSIZE *PSIZE; alias tagSIZE *LPSIZE; }q{
+alias tagSIZE SIZE; alias tagSIZE *PSIZE; alias tagSIZE *LPSIZE; } ~ q{
  // WIN16
 };
 else // !remove_pp
@@ -2831,7 +2831,7 @@ unittest
 	hallo2
 ";
 	string exptxt = "
-int convert() { return  " "
+int convert() { return  " ~ "
 	hello; }
 // #define noconvert(n,m) \\
 //	hallo1 |\\
@@ -2930,7 +2930,7 @@ alias _PROPSHEETPAGEA_V2 _PROPSHEETPAGEA;
 } else {
 
 alias _PROPSHEETPAGEA_V1 _PROPSHEETPAGEA;
-} " "
+} " ~ "
 
 ";
 	testConvert(txt, exptxt, "prsht");

--- a/nsis/visuald.nsi
+++ b/nsis/visuald.nsi
@@ -315,6 +315,7 @@ ${MementoSection} "Install in VS 2010" SecVS2010
   ${RegisterWin32Exception} ${VS2010_REGISTRY_KEY} "Win32 Exceptions\D Exception"
 
   ReadRegStr $1 ${VS_REGISTRY_ROOT} "${VS2010_REGISTRY_KEY}" InstallDir
+  RMDir /r '$1${EXTENSION_DIR_APP}'
   ExecWait 'rundll32 "$INSTDIR\${DLLNAME}" WritePackageDef ${VS2010_REGISTRY_KEY} $1${EXTENSION_DIR}\visuald.pkgdef'
   ${AddItem} "$1${EXTENSION_DIR}\visuald.pkgdef"
 
@@ -341,6 +342,7 @@ ${MementoSection} "Install in VS 2012" SecVS2012
   ${RegisterWin32Exception} ${VS2012_REGISTRY_KEY} "Win32 Exceptions\D Exception"
 
   ReadRegStr $1 ${VS_REGISTRY_ROOT} "${VS2012_REGISTRY_KEY}" InstallDir
+  RMDir /r '$1${EXTENSION_DIR_APP}'
   ExecWait 'rundll32 "$INSTDIR\${DLLNAME}" WritePackageDef ${VS2012_REGISTRY_KEY} $1${EXTENSION_DIR}\visuald.pkgdef'
   ${AddItem} "$1${EXTENSION_DIR}\visuald.pkgdef"
 
@@ -373,6 +375,7 @@ ${MementoSection} "Install in VS 2013" SecVS2013
   ${RegisterWin32Exception} ${VS2013_REGISTRY_KEY} "Win32 Exceptions\D Exception"
 
   ReadRegStr $1 ${VS_REGISTRY_ROOT} "${VS2013_REGISTRY_KEY}" InstallDir
+  RMDir /r '$1${EXTENSION_DIR_APP}'
   ExecWait 'rundll32 "$INSTDIR\${DLLNAME}" WritePackageDef ${VS2013_REGISTRY_KEY} $1${EXTENSION_DIR}\visuald.pkgdef'
   ${AddItem} "$1${EXTENSION_DIR}\visuald.pkgdef"
   
@@ -405,6 +408,7 @@ ${MementoSection} "Install in VS 2015" SecVS2015
   ${RegisterWin32Exception} ${VS2015_REGISTRY_KEY} "Win32 Exceptions\D Exception"
 
   ReadRegStr $1 ${VS_REGISTRY_ROOT} "${VS2015_REGISTRY_KEY}" InstallDir
+  RMDir /r '$1${EXTENSION_DIR_APP}'
   ExecWait 'rundll32 "$INSTDIR\${DLLNAME}" WritePackageDef ${VS2015_REGISTRY_KEY} $1${EXTENSION_DIR}\visuald.pkgdef'
   ${AddItem} "$1${EXTENSION_DIR}\visuald.pkgdef"
 
@@ -438,6 +442,7 @@ ${MementoSection} "Install in VS 2017" SecVS2017
 
   ReadRegStr $1 ${VS_REGISTRY_ROOT} "${VS2017_INSTALL_KEY}" "15.0"
   StrCpy $1 "$1Common7\IDE\"
+  RMDir /r '$1${EXTENSION_DIR_APP}'
   ExecWait 'rundll32 "$INSTDIR\${DLLNAME}" WritePackageDef ${VS2017_REGISTRY_KEY} $1${EXTENSION_DIR}\visuald.pkgdef'
   ${AddItem} "$1${EXTENSION_DIR}\visuald.pkgdef"
 

--- a/vdc/abothe/comserver/VDServer.cs
+++ b/vdc/abothe/comserver/VDServer.cs
@@ -256,8 +256,8 @@ namespace DParserCOMServer
 			try
 			{
 				ast = DParser.ParseString(srcText, false, true, _taskTokens);
-			}
-			catch(Exception ex)
+            }
+            catch (Exception ex)
 			{
 				ast = new DModule{ ParseErrors = new System.Collections.ObjectModel.ReadOnlyCollection<ParserError>(
 						new List<ParserError>{
@@ -441,7 +441,7 @@ namespace DParserCOMServer
                                 v = Evaluation.EvaluateValue(var.Initializer, ctxt);
                             if (v == null && sr is IExpression)
                                 v = Evaluation.EvaluateValue(sr as IExpression, ctxt);
-                            if (v != null)
+                            if (v != null && !(v is ErrorValue))
                                 tipText.Append("\avalue = ").Append(v.ToString());
                         }
                         catch (Exception e)

--- a/vdc/abothe/comserver/VDServer.cs
+++ b/vdc/abothe/comserver/VDServer.cs
@@ -768,7 +768,9 @@ namespace DParserCOMServer
         ///////////////////////////////////
 		void _setupEditorData()
 		{
-			string versions = _versionIds;
+			string versions	= _versionIds;
+			if (!String.IsNullOrEmpty(versions)	&& !versions.EndsWith("\n"))
+				versions += "\n";
 			versions += "Windows\n" + "LittleEndian\n" + "D_HardFloat\n" + "all\n" + "D_Version2\n";
 			if ((_flags & 1) != 0)
 				versions += "unittest\n";

--- a/visuald/colorizer.d
+++ b/visuald/colorizer.d
@@ -1408,7 +1408,10 @@ class Colorizer : DisposingComObject, IVsColorizer, ConfigModifiedListener
 		if(mConfig)
 		{
 			ProjectOptions opts = mConfig.GetProjectOptions();
-			changes += modifyValue(opts.versionids,    mConfigVersions[kIndexVersion]);
+
+			string versionids = mConfig.getCompilerVersionIDs();
+
+			changes += modifyValue(versionids,         mConfigVersions[kIndexVersion]);
 			changes += modifyValue(opts.debugids,      mConfigVersions[kIndexDebug]);
 			changes += modifyValue(opts.release,       mConfigRelease);
 			changes += modifyValue(opts.useUnitTests,  mConfigUnittest);

--- a/visuald/dlangsvc.d
+++ b/visuald/dlangsvc.d
@@ -881,8 +881,8 @@ class LanguageService : DisposingComObject,
 			if (cfgopts.addDepImp)
 				foreach(dep; cfg.getImportsFromDependentProjects())
 					imp.addunique(dep);
-
-			versionids = tokenizeArgs(cfgopts.versionids);
+			string versions = cfg.getCompilerVersionIDs();
+			versionids = tokenizeArgs(versions);
 			debugids = tokenizeArgs(cfgopts.debugids);
 		}
 		else

--- a/visuald/dpackage.d
+++ b/visuald/dpackage.d
@@ -1235,8 +1235,11 @@ struct CompilerDirectories
 	{
 		return detectCompilerVersion(InstallDir);
 	}
-
-	bool detectCompilerVersion(string instdir)
+	string getCompilerPath()
+	{
+		return getCompilerPath(InstallDir);
+	}
+	string getCompilerPath(string instdir)
 	{
 		string exe;
 		if (compiler == Compiler.DMD)
@@ -1252,7 +1255,12 @@ struct CompilerDirectories
 			exe = "bin\\gdc.exe";
 		}
 		exe = normalizeDir(instdir) ~ exe;
+		return exe;
+	}
 
+	bool detectCompilerVersion(string instdir)
+	{
+		string exe = getCompilerPath(instdir);
 		try
 		{
 			if(std.file.exists(exe))
@@ -1355,6 +1363,7 @@ class GlobalOptions
 	bool lastColorizeCoverage;
 	bool lastColorizeVersions;
 	bool lastUseDParser;
+	string lastInstallDirs;
 
 	int vsVersion;
 	bool isVS2017() { return vsVersion == 15; }
@@ -1834,6 +1843,7 @@ class GlobalOptions
 			UserTypesSpec     = getStringOpt("UserTypesSpec", defUserTypesSpec);
 			UserTypes = parseUserTypes(UserTypesSpec);
 
+			lastInstallDirs      = DMD.InstallDir ~ ";" ~ GDC.InstallDir ~ ";" ~ LDC.InstallDir;
 			lastColorizeCoverage = ColorizeCoverage;
 			lastColorizeVersions = ColorizeVersions;
 			lastUseDParser       = useDParser;
@@ -1982,6 +1992,12 @@ class GlobalOptions
 		if(lastColorizeCoverage != ColorizeCoverage)
 		{
 			lastColorizeCoverage = ColorizeCoverage;
+			updateColorizer = true;
+		}
+		string installDirs = DMD.InstallDir ~ ";" ~ GDC.InstallDir ~ ";" ~ LDC.InstallDir;
+		if(lastInstallDirs != installDirs)
+		{
+			lastInstallDirs = installDirs;
 			updateColorizer = true;
 		}
 		if(updateColorizer)


### PR DESCRIPTION
Changes:
- installer and binaries now digitally signed by the "D Language Foundation"
- installer now removes old extension folders before installation
- predefined versions now evaluated by compiler invocation
- the last user specified version was prepended to "Windows"
- mago debug engine: the disassemble view now supports SSE4 and AVX
- dparser: fix stack overflow with "static foreach"
- dparser: some improvements to expression evaluation
- expression evaluation in tooltip not shown for "normal" error
