### PR TITLE
Visual D 0.50.0-beta3

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -2,4 +2,4 @@
 #define VERSION_MINOR      50
 #define VERSION_REVISION   0
 #define VERSION_BETA       -beta
-#define VERSION_BUILD      2
+#define VERSION_BUILD      3

--- a/msbuild/dbuild/CompileD.cs
+++ b/msbuild/dbuild/CompileD.cs
@@ -38,6 +38,7 @@ namespace dbuild
             this.switchOrderList.Add("StackStomp");
             this.switchOrderList.Add("AllInst");
             this.switchOrderList.Add("Main");
+            this.switchOrderList.Add("LowMem");
             this.switchOrderList.Add("DebugCode");
             this.switchOrderList.Add("DebugInfo");
             this.switchOrderList.Add("DebugFull");
@@ -386,6 +387,17 @@ namespace dbuild
                 SetBoolProperty("Main", "Add Main",
                                 "Add default main() (e.g. for unittesting) (-main)",
                                 "-main", value);
+            }
+        }
+
+        public bool LowMem
+        {
+            get { return GetBoolProperty("LowMem"); }
+            set
+            {
+                SetBoolProperty("LowMem", "Low Memory Usage",
+                                "Use garbage collector to reduce memory needed by the compiler (-lowmem)",
+                                "-lowmem", value);
             }
         }
 
@@ -1031,6 +1043,24 @@ namespace dbuild
         {
             applyParameters(parameters);
             return GenerateCommandLineExceptSwitches(new string[0]);
+        }
+
+#if TOOLS_V14 || TOOLS_V15
+        protected override string GenerateCommandLineCommandsExceptSwitches(string[] switchesToRemove, VCToolTask.CommandLineFormat format = VCToolTask.CommandLineFormat.ForBuildLog, VCToolTask.EscapeFormat escapeFormat = VCToolTask.EscapeFormat.Default)
+        {
+            string cmd = base.GenerateCommandLineCommandsExceptSwitches(switchesToRemove, format, escapeFormat);
+#else
+        protected override string GenerateCommandLineCommands(VCToolTask.CommandLineFormat format = VCToolTask.CommandLineFormat.ForBuildLog)
+        {
+            string cmd = base.GenerateCommandLineCommands(format);
+#endif
+            // must be outside of response file
+            if (LowMem)
+                if (string.IsNullOrEmpty(cmd))
+                    cmd = " -lowmem";
+                else
+                    cmd += " -lowmem"; // must be outside of response file
+            return cmd;
         }
 
         public override bool Execute()

--- a/msbuild/dcompile.targets
+++ b/msbuild/dcompile.targets
@@ -221,6 +221,7 @@
               ShowGC="%(DCompile.ShowGC)"
               IgnorePragma="%(DCompile.IgnorePragma)"
               ShowDependencies="%(DCompile.ShowDependencies)"
+              LowMem="%(DCompile.LowMem)"
 
               DocDir="%(DCompile.DocDir)"
               DocFile="%(DCompile.DocFile)"

--- a/msbuild/dcompile_defaults.props
+++ b/msbuild/dcompile_defaults.props
@@ -76,6 +76,7 @@
       <PerformSyntaxCheckOnly>false</PerformSyntaxCheckOnly>
       <PreserveSourcePath>false</PreserveSourcePath>
       <Main>false</Main>
+      <LowMem>false</LowMem>
       <ShowDependencies>false</ShowDependencies>
       <VersionIdentifiers></VersionIdentifiers>
       <DebugIdentifiers></DebugIdentifiers>

--- a/msbuild/dmd.xml
+++ b/msbuild/dmd.xml
@@ -68,7 +68,8 @@
         <DataSource Persistence="ProjectFile" ItemType="" Label="" HasConfigurationCondition="true" />
       </BoolProperty.DataSource>
     </BoolProperty>
-
+    <BoolProperty Name="LowMem" Category="General" DisplayName="Enable garbage collection for the compiler"
+                  Description="Uses less memory for the compilation at the cost of slower compilation. (-lowmem)" Switch="-lowmem" />
 
     <!-- =============== Messages =============== -->
     <EnumProperty Name="Warnings" Category="Messages" DisplayName="Enable warnings" Description="Enable display of warnings. (-w, -wi)">

--- a/msbuild/ldc.xml
+++ b/msbuild/ldc.xml
@@ -68,6 +68,8 @@
         <DataSource Persistence="ProjectFile" ItemType="" Label="" HasConfigurationCondition="true" />
       </BoolProperty.DataSource>
     </BoolProperty>
+    <BoolProperty Name="LowMem" Category="General" DisplayName="Enable garbage collection for the compiler"
+                  Description="Uses less memory for the compilation at the cost of slower compilation. (-lowmem)" Switch="-lowmem" />
 
     <!-- =============== Messages =============== -->
     <EnumProperty Name="Warnings" Category="Messages" DisplayName="Enable warnings" Description="Enable display of warnings. (-w, -wi)">

--- a/nsis/visuald.nsi
+++ b/nsis/visuald.nsi
@@ -90,9 +90,9 @@
   Caption "${LONG_APPNAME} ${VERSION} Setup"
 !ifdef DMD
   !ifdef LDC
-    !define OUT_SUFFIX "-dmd${DMD_VERSION}-ldc2-${LDC_VERSION}"
+    !define OUT_SUFFIX "-dmd-${DMD_VERSION}-ldc2-${LDC_VERSION}"
   !else
-    !define OUT_SUFFIX "-dmd${DMD_VERSION}"
+    !define OUT_SUFFIX "-dmd-${DMD_VERSION}"
   !endif
 !else
   !define OUT_SUFFIX ""
@@ -330,7 +330,7 @@ ${MementoSection} "Install DMD" SecDMD
 
   ; not using ${File} to keep compiler even if Visual D uninstalled
 
-  !define DmdBaseDir "$CompilerInstallDir\dmd${DMD_VERSION}"
+  !define DmdBaseDir "$CompilerInstallDir\dmd-${DMD_VERSION}"
   ${SetOutPath} "${DmdBaseDir}"
   File /r ${DMD_SRC}\html
   File /r ${DMD_SRC}\samples
@@ -911,6 +911,7 @@ SectionEnd
   LangString DESC_SecVS2013 ${LANG_ENGLISH} "Register for usage in Visual Studio 2013."
   LangString DESC_SecVS2015 ${LANG_ENGLISH} "Register for usage in Visual Studio 2015."
   LangString DESC_SecVS2017 ${LANG_ENGLISH} "Register for usage in Visual Studio 2017."
+  LangString DESC_SecVS2019 ${LANG_ENGLISH} "Register for usage in Visual Studio 2019."
 !ifdef EXPRESS
   LangString DESC_SecVCExpress2008 ${LANG_ENGLISH} "Register for usage in Visual C++ Express 2008 (experimental and unusable)."
   LangString DESC_SecVCExpress2010 ${LANG_ENGLISH} "Register for usage in Visual C++ Express 2010 (experimental and unusable)."
@@ -946,6 +947,7 @@ SectionEnd
     !insertmacro MUI_DESCRIPTION_TEXT ${SecVS2013} $(DESC_SecVS2013)
     !insertmacro MUI_DESCRIPTION_TEXT ${SecVS2015} $(DESC_SecVS2015)
     !insertmacro MUI_DESCRIPTION_TEXT ${SecVS2017} $(DESC_SecVS2017)
+    !insertmacro MUI_DESCRIPTION_TEXT ${SecVS2019} $(DESC_SecVS2019)
 !ifdef EXPRESS
     !insertmacro MUI_DESCRIPTION_TEXT ${SecVCExpress2008} $(DESC_SecVCExpress2008)
     !insertmacro MUI_DESCRIPTION_TEXT ${SecVCExpress2008} $(DESC_SecVCExpress2010)
@@ -1281,7 +1283,7 @@ Function DMDInstallPage
     IfErrors 0 HasDInstallationFolder
     ReadRegStr $DInstallDir HKLM "SOFTWARE\D" "Install_Dir" 
     IfErrors 0 HasDInstallationFolder
-    StrCpy $DInstallDir "c:\D"
+    StrCpy $DInstallDir "C:\D"
   HasDInstallationFolder:
     StrCpy $CompilerInstallDir $DInstallDir
   HasCompilerInstallDir:

--- a/stdext/string.d
+++ b/stdext/string.d
@@ -261,7 +261,7 @@ bool _startsWith(string s, string w)
 //alias startsWith _startsWith;
 
 // munch deprecated in phobos
-char[] _munch(ref char[] s, const(char)[] pattern) @safe pure @nogc
+inout(char)[] _munch(ref inout(char)[] s, const(char)[] pattern) @safe pure @nogc
 {
 	size_t j = s.length;
 	foreach (i, dchar c; s)
@@ -272,12 +272,12 @@ char[] _munch(ref char[] s, const(char)[] pattern) @safe pure @nogc
 			break;
 		}
 	}
-	char[] head = s[0 .. j];
+	auto head = s[0 .. j];
 	s = s[j .. $];
 	return head;
 }
 
-bool parseLong(ref char[] txt, out long res)
+bool parseLong(ref const(char)[] txt, out long res)
 {
 	_munch(txt, " \t\n\r");
 	int n = 0;
@@ -290,13 +290,13 @@ bool parseLong(ref char[] txt, out long res)
 	return true;
 }
 
-char[] parseNonSpace(ref char[] txt)
+inout(char)[] parseNonSpace(ref inout(char)[] txt)
 {
 	_munch(txt, " \t\n\r");
 	int n = 0;
 	while(n < txt.length && !isWhite(txt[n]))
 		n++;
-	char[] res = txt[0..n];
+	auto res = txt[0..n];
 	txt = txt[n..$];
 	return res;
 }

--- a/visuald/dlangsvc.d
+++ b/visuald/dlangsvc.d
@@ -262,7 +262,7 @@ class LanguageService : DisposingComObject,
 		*/
 		*pbstrName = null;
 		*piLineOffset = 0;
-		return S_OK;
+		return E_FAIL;
 	}
 
 	override HRESULT GetProximityExpressions(IVsTextBuffer pBuffer, in int iLine, in int iCol, in int cLines, IVsEnumBSTR* ppEnum)

--- a/visuald/profiler.d
+++ b/visuald/profiler.d
@@ -2036,14 +2036,14 @@ class ProfileItemIndex
 				}
 				else if(curItem)
 				{
-					char[] txt = buf;
+					const(char)[] txt = buf;
 					_munch(txt, " \t\n\r");
 					if(txt.length > 0 && isDigit(txt[0]))
 					{
 						long calls;
 						if(parseLong(txt, calls))
 						{
-							char[] id = parseNonSpace(txt);
+							auto id = parseNonSpace(txt);
 							if(id.length > 0)
 							{
 								_munch(txt, " \t\n\r");
@@ -2061,7 +2061,7 @@ class ProfileItemIndex
 					else if(txt.length > 0)
 					{
 						long calls, treeTime, funcTime;
-						char[] id = parseNonSpace(txt);
+						auto id = parseNonSpace(txt);
 						if(id.length > 0 &&
 						   parseLong(txt, calls) &&
 						   parseLong(txt, treeTime) &&

--- a/visuald/propertypage.d
+++ b/visuald/propertypage.d
@@ -2985,6 +2985,7 @@ struct MagoOptions
 	bool showVTable;
 	bool flatClassFields;
 	bool expandableStrings;
+	uint maxArrayElements;
 
 	void saveToRegistry()
 	{
@@ -2994,6 +2995,7 @@ struct MagoOptions
 		keyMago.Set("showVTable", showVTable);
 		keyMago.Set("flatClassFields", flatClassFields);
 		keyMago.Set("expandableStrings", expandableStrings);
+		keyMago.Set("maxArrayElements", maxArrayElements);
 	}
 
 	void loadFromRegistry()
@@ -3005,6 +3007,7 @@ struct MagoOptions
 		showVTable        = (keyMago.GetDWORD("showVTable", 1) != 0);
 		flatClassFields   = (keyMago.GetDWORD("flatClassFields", 0) != 0);
 		expandableStrings = (keyMago.GetDWORD("expandableStrings", 0) != 0);
+		maxArrayElements  =  keyMago.GetDWORD("maxArrayElements", 1000);
 	}
 }
 
@@ -3023,6 +3026,10 @@ class MagoPropertyPage : ResizablePropertyPage
 		AddControl("", mShowVTable        = new CheckBox(mCanvas, "Show virtual function table as field of classes"));
 		AddControl("", mFlatClassFields   = new CheckBox(mCanvas, "Show base class fields as direct fields"));
 		AddControl("", mExpandableStrings = new CheckBox(mCanvas, "Expand strings to show array of characters"));
+		auto saveWidth = kLabelWidth;
+		kLabelWidth = kPageWidth * 4 / 5;
+		AddControl("Limit array elements shown in expansions to", mMaxArrayElements = new Text(mCanvas));
+		kLabelWidth  = saveWidth;
 	}
 
 	override void UpdateDirty(bool bDirty)
@@ -3069,6 +3076,7 @@ class MagoPropertyPage : ResizablePropertyPage
 		mShowVTable.setChecked(mOptions.showVTable);
 		mFlatClassFields.setChecked(mOptions.flatClassFields);
 		mExpandableStrings.setChecked(mOptions.expandableStrings);
+		mMaxArrayElements.setText(to!string(mOptions.maxArrayElements));
 	}
 
 	int DoApply(ref MagoOptions opts, ref MagoOptions refopts)
@@ -3079,6 +3087,12 @@ class MagoPropertyPage : ResizablePropertyPage
 		changes += changeOption(mShowVTable.isChecked(), opts.showVTable, refopts.showVTable);
 		changes += changeOption(mFlatClassFields.isChecked(), opts.flatClassFields, refopts.flatClassFields);
 		changes += changeOption(mExpandableStrings.isChecked(), opts.expandableStrings, refopts.expandableStrings);
+
+		import stdext.string;
+		long maxelem;
+		const(char)[] txt = mMaxArrayElements.getText();
+		if (parseLong(txt, maxelem))
+			changes += changeOption(cast(uint)maxelem, opts.maxArrayElements, refopts.maxArrayElements);
 		return changes;
 	}
 
@@ -3087,6 +3101,7 @@ class MagoPropertyPage : ResizablePropertyPage
 	CheckBox mShowVTable;
 	CheckBox mFlatClassFields;
 	CheckBox mExpandableStrings;
+	Text mMaxArrayElements;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/visuald/propertypage.d
+++ b/visuald/propertypage.d
@@ -2532,7 +2532,7 @@ class UpdatePropertyPage : GlobalPropertyPage
 		auto info = checkForUpdate(CheckProduct.VisualD, -1.days, opts.checkUpdatesVisualD);
 		updateVisualDInfo(info);
 
-		info = checkForUpdate(CheckProduct.DMD, -1.days, opts.checkUpdatesVisualD);
+		info = checkForUpdate(CheckProduct.DMD, -1.days, opts.checkUpdatesDMD);
 		updateDMDInfo(info);
 
 		info = checkForUpdate(CheckProduct.LDC, -1.days, opts.checkUpdatesLDC);

--- a/visuald/updates.d
+++ b/visuald/updates.d
@@ -531,7 +531,7 @@ void doUpdate(string baseDir, CheckProduct prod, int frequency, void delegate(st
 					break;
 
 				case CheckProduct.DMD:
-					string dmdname = info.name.replace(" ", "").toLower();
+					string dmdname = info.name.replace(" ", "-").toLower();
 					string dmd2x = buildPath(baseDir, dmdname);
 					unzipCompiler(tgtfile, "dmd2", dmd2x);
 					Package.GetGlobalOptions().DMD.InstallDir = dmd2x;

--- a/visuald/updates.d
+++ b/visuald/updates.d
@@ -118,7 +118,9 @@ UpdateInfo* checkForUpdate(CheckProduct prod, Duration renew, int frequency)
 	{
 		auto info = new UpdateInfo;
 		info.name = "DMD " ~ txt;
-		info.download_url = "http://" ~ domain ~ url[0..$-6] ~ "2.x/" ~ txt ~ "/dmd." ~ txt ~ ".windows.7z";
+		auto verinfo = extractVersion(txt);
+		auto ver = verinfo.major ~ "." ~ verinfo.minor ~ "." ~ verinfo.rev;
+		info.download_url = "http://" ~ domain ~ url[0..$-6] ~ verinfo.major ~ ".x/" ~ ver ~ "/dmd." ~ txt ~ ".windows.7z";
 		info.lastCheck = modTime;
 		info.updated = updated;
 		return info;


### PR DESCRIPTION
- slightly improve dmd directory names
- updates:
  - fix link to dmd prerelease download
  - wrong frequency used for DMD
  - check DMD releases with prerelases, too
  - display HTML error
- mago: limit maximum number of elements for an array
- add option -lowmem
