### PR TITLE
Visual D 0.50.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1154,7 +1154,7 @@ Version history
   * fixed "go to definition" eventually not jumping to correct line after opening document
   * scale dialogs according to current text font size, i.e. adapt to DPI scaling
 
-unreleased Version 0.50.1
+2019-09-03 Version 0.50.1
   * msbuild: fix parallel build in VS 2019 16.1
   * msbuild: fix building right after full installation
   * bugzilla 20003: project properties: show "Better C" in option text
@@ -1171,5 +1171,6 @@ unreleased Version 0.50.1
     Run/Debug now use "dmd -i" instead of "rdmd"
   * version highlighting for source files not in a project now reads settings from startup project
   * highlight x64 registers in asm block
+  * don't highlight asm keywords/mnemonics/registers from semantic information
   * VS 2019 16.2: command line options no longer read correctly from the VC project for
     Compile and Run/Debug/Disassemble, dbuild refactored to not rely on msbuild DLLs for that

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 #define VERSION_MAJOR      0
 #define VERSION_MINOR      50
 #define VERSION_REVISION   1
-#define VERSION_BETA       -rc
-#define VERSION_BUILD      2
+#define VERSION_BETA       
+#define VERSION_BUILD      0

--- a/build_doc.bat
+++ b/build_doc.bat
@@ -1,6 +1,8 @@
+setlocal
 set DMD=c:\s\d\rainers\windows\bin\dmd.exe
 rem set WEB=m:\s\d\rainers\web\visuald
 set WEB=c:\s\d\visuald\gh-pages\visuald
+set CP=c:\u\gnuwin\cp.exe
 
 set SRC=      doc/ReportingBugs.dd
 set SRC=%SRC% doc/StartPage.dd
@@ -31,15 +33,15 @@ rem ..\..\rainers\d-programming-language.org\dlang.org.ddoc
 
 if not exist %WEB% md %WEB%
 if not exist %WEB%\images md %WEB%\images
-cp -u doc/images/* %WEB%\images
+%cp% -u doc/images/* %WEB%\images
 
 if not exist %WEB%\css md %WEB%\css
-cp -u doc/css/* %WEB%\css
+%cp% -u doc/css/* %WEB%\css
 
 if not exist %WEB%\js md %WEB%\js
-cp -u doc/js/* %WEB%\js
+%cp% -u doc/js/* %WEB%\js
 
-cp -u doc/favicon.ico %WEB%
+%cp% -u doc/favicon.ico %WEB%
 
 %DMD% -Dd%WEB% -o- -w %DDOC% %SRC%
 

--- a/doc/StartPage.dd
+++ b/doc/StartPage.dd
@@ -84,7 +84,14 @@ $(H2 News)
 $(P $(LINK2 VersionHistory.html, Full version history and complete details...)
 )
 
-2019-05-24 Version 0.50.0
+2019-09-03 Version 0.50.1
+$(UL
+ $(LI Fixes some integration issues with VS 2019 16.2)
+ $(LI mago: improve function call in watch window)
+ $(LI better version highlighting for files not in project)
+)
+
+2019-06-23 Version 0.50.0
 $(UL
  $(LI Now checks for updates of Visual D, DMD and LDC and assists download and install)
  $(LI Setup including DMD and LDC now available)

--- a/doc/VersionHistory.dd
+++ b/doc/VersionHistory.dd
@@ -1,5 +1,42 @@
 Ddoc
 
+$(H2 2019-09-03 Version 0.50.1)
+ $(UL
+  $(LI installer:
+   $(UL
+    $(LI msbuild: fix building right after full installation)
+    $(LI bugzilla 20004: add button to reset all global settings to their default)
+    $(LI bugzilla 20005: try to detect VC through ISetupConfiguration, too)
+  ))
+  $(LI VC project:
+   $(UL
+    $(LI bugzilla 20003: project properties: show "Better C" in option text)
+    $(LI release configurations in new projects now default to -release -O -inline)
+    $(LI Compile and Compile/Run/Debug/Disassemble didn't use all command line options,
+         Run/Debug now use "dmd -i" instead of "rdmd")
+    $(LI fix parallel build in VS 2019 16.1)
+    $(LI VS 2019 16.2: fix command line options no longer read correctly from the VC project for
+         Compile and Run/Debug/Disassemble)
+  ))
+  $(LI editor:
+   $(UL
+    $(LI version highlighting for source files not in a project now reads settings from startup project)
+    $(LI highlight x64 registers in asm block)
+    $(LI don't highlight asm keywords/mnemonics/registers from semantic information)
+  ))
+  $(LI mago:
+   $(UL
+    $(LI improve function call in watch window
+     $(UL
+      $(LI implement virtual functions, fix calling delegates and function pointers)
+      $(LI display of delegate type)
+      $(LI support arbitrary return types)
+    ))
+	$(LI fix showing UTF32 values (supported by dmd 2.089))
+    $(LI fix reading enum values (not emitted before dmd 2.089))
+  ))
+ )
+
 $(H2 2019-06-23 Version 0.50.0)
  $(UL
   $(LI installer:

--- a/doc/visuald.ddoc
+++ b/doc/visuald.ddoc
@@ -1,6 +1,6 @@
-VERSION = 0.50.0
-DMD_VERSION = 2.086.1
-LDC_VERSION = 1.16.0
+VERSION = 0.50.1
+DMD_VERSION = 2.087.1
+LDC_VERSION = 1.17.0
 ROOT_DIR = https://www.dlang.org/
 ROOT = https://www.dlang.org
 BODYCLASS = visuald

--- a/visuald/colorizer.d
+++ b/visuald/colorizer.d
@@ -388,15 +388,15 @@ class Colorizer : DisposingComObject, IVsColorizer, ConfigModifiedListener
 						type = TokenColor.Keyword;
 				}
 
-			if (type == TokenColor.Identifier)
-				type = mSource.getIdentifierColor(tok, iLine + 1, prevpos);
-
 			if(cov >= 0)
 			{
 				type = covtype;
 			}
 			else
 			{
+				if (type == TokenColor.Identifier)
+					type = mSource.getIdentifierColor(tok, iLine + 1, prevpos);
+
 				if(mColorizeVersions)
 				{
 					if(Lexer.isCommentOrSpace(type, tok) || (inTokenString || nowInTokenString))
@@ -888,6 +888,13 @@ class Colorizer : DisposingComObject, IVsColorizer, ConfigModifiedListener
 		return type;
 	}
 
+	// anything that originates from TokenColor.Identifier
+	bool isIdentifierColorType(int type)
+	{
+		int sct = stringColorType(type);
+		return sct == TokenColor.StringIdentifier || sct == TokenColor.DisabledIdentifier;
+	}
+
 	__gshared int[wstring] asmIdentifiers;
 	static const wstring[] asmKeywords = [ "__LOCAL_SIZE", "dword", "even", "far", "naked", "near", "ptr", "qword", "seg", "word", ];
 	static const wstring[] asmRegisters = [
@@ -1220,13 +1227,13 @@ class Colorizer : DisposingComObject, IVsColorizer, ConfigModifiedListener
 		case VersionParseState.InAsmBlockEnabled:
 			if(text == "}")
 				parseState = VersionParseState.IdleEnabled;
-			else if(ntype == TokenColor.Identifier)
+			else if(isIdentifierColorType(ntype))
 				ntype = asmColorType(text);
 			break;
 		case VersionParseState.InAsmBlockDisabled:
 			if(text == "}")
 				parseState = VersionParseState.IdleDisabled;
-			else if(ntype == TokenColor.Identifier)
+			else if(isIdentifierColorType(ntype))
 				ntype = asmColorType(text);
 			goto case VersionParseState.IdleDisabled;
 		}


### PR DESCRIPTION
 - don't highlight asm keywords/mnemonics/registers from semantic information