### PR TITLE
Visual D 1.0.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1243,13 +1243,13 @@ Version history
     - vcxproj: only print the filename in the "Compiling" message, not the path
 
 unreleased version 1.0.0
-  * Visual D and all tools now built with LDC
   * projects:
     - trailing \ now removed from $(WindowsSDKVersion)/$(UCRTVersion) for more consistency between
       autodetected version and as read from the environment
     - added global option "Echo batch commands executed" to show commands during builds
     - workaround /noopttls no longer added when building with LDC or dmd 2.076+
   * dmdserver:
+    - now built with LDC
     - now enabled by default including semantic highlighting
     - updated to dmd 2.092
     - improve preciseness for the GC
@@ -1263,5 +1263,7 @@ unreleased version 1.0.0
   * mago debugger
     - can now execute class/struct methods __debugOverview, __debugExpanded, __debugTextView
       to customize display in the debugger
-    - can now display ranges similar to arrays
+    - experimental: can now display ranges similar to arrays
     - some performance improvements by caching some data while the debuggee is stopped
+  * installer:
+    - full installer now bundled with dmd 2.092.1 and LDC 1.22.0

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ MSBUILD15 = "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBui
 !IF !EXIST($(MSBUILD15))
 MSBUILD15 = "c:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\msbuild"
 !ENDIF
-CONFIG  = Release LDC
+# CONFIG  = Release LDC
+CONFIG  = Release COFF32
+CONFIG_DMDSERVER = Release LDC
 
 ##############################################################
 # no more changes should be necessary starting from here
@@ -65,7 +67,7 @@ vdserver:
 	devenv /Project "vdserver"  /Build "$(CONFIG)|Win32" visuald_vs10.sln
 
 dmdserver:
-	devenv /Project "dmdserver" /Build "$(CONFIG)|x64" visuald_vs10.sln
+	devenv /Project "dmdserver" /Build "$(CONFIG_DMDSERVER)|x64" visuald_vs10.sln
 
 dmdserver_test:
 	devenv /Project "dmdserver" /Build "TestDebug|x64" visuald_vs10.sln
@@ -180,4 +182,4 @@ install_modules: prerequisites visuald_vs vdserver dmdserver vdextension vdext15
 
 install_only:
 	if not exist ..\downloads\nul md ..\downloads
-	cd nsis && "$(NSIS)\makensis" /V1 "/DCONFIG=$(CONFIG)" $(NSIS_ARGS) visuald.nsi
+	cd nsis && "$(NSIS)\makensis" /V1 "/DCONFIG=$(CONFIG)" "/DCONFIG_DMDSERVER=$(CONFIG_DMDSERVER)" $(NSIS_ARGS) visuald.nsi

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 #define VERSION_MAJOR      1
 #define VERSION_MINOR      0
 #define VERSION_REVISION   0
-#define VERSION_BETA       -beta
-#define VERSION_BUILD      2
+#define VERSION_BETA       
+#define VERSION_BUILD      0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,7 @@ install:
   # show environment
   - set D_COMPILER=dmd
   - set CONFIG=Release COFF32
+  - set CONFIG_DMDSERVER=Release COFF32
   - set
   - cd c:\projects
   - if not exist cache\nul mkdir cache
@@ -110,7 +111,7 @@ build_script:
   # build Visual D
   - nmake "CONFIG=%CONFIG%" visuald_vs
   # build and run Visual D unittests
-  - nmake "CONFIG=%CONFIG%" visuald_test dmdserver_test
+  - nmake "CONFIG=%CONFIG%" "CONFIG_DMDSERVER=%CONFIG_DMDSERVER%" visuald_test dmdserver_test
   - cd ..
   # Clone mago/cv2pdb (need to be two levels up)
   - cd ..
@@ -136,8 +137,8 @@ build_script:
   - cd visuald
   # can build dbuild15 and dparser only with VS2017
   - if     "%VS%"=="15" nuget restore vdc\abothe\VDServer.sln
-  - if     "%VS%"=="15" nmake "CONFIG=%CONFIG%" install_vs_only_vs2017
-  - if not "%VS%"=="15" nmake "CONFIG=%CONFIG%" install_vs_no_vs2017
+  - if     "%VS%"=="15" nmake "CONFIG=%CONFIG%" "CONFIG_DMDSERVER=%CONFIG_DMDSERVER%" install_vs_only_vs2017
+  - if not "%VS%"=="15" nmake "CONFIG=%CONFIG%" "CONFIG_DMDSERVER=%CONFIG_DMDSERVER%" install_vs_no_vs2017
 
 after_build:
   # publish as artifact

--- a/doc/StartPage.dd
+++ b/doc/StartPage.dd
@@ -84,6 +84,14 @@ $(H2 News)
 $(P $(LINK2 VersionHistory.html, Full version history and complete details...)
 )
 
+2020-07-04 Version 1.0.0
+$(UL
+ $(LI DMD based semantic engine: enabled by default, updated to front end version 2.092)
+ $(LI mago: customize debugger display with methods/fields __debugOverview, __debugExpanded, __debugTextView)
+ $(LI navigation bar: display and change current edit scope)
+ $(LI goto definition by clicking identifier in tool tip)
+)
+
 2020-23-03 Version 0.52.0
 $(UL
  $(LI mago: added support for tuples and simpler display of globals)

--- a/doc/VersionHistory.dd
+++ b/doc/VersionHistory.dd
@@ -1,5 +1,43 @@
 Ddoc
 
+$(H2 2020-07-04 Version 1.0.0)
+ $(UL
+  $(LI project management:
+   $(UL
+    $(LI trailing \ now removed from $(WindowsSDKVersion)/$(UCRTVersion) for more consistency between
+      autodetected version and as read from the environment)
+    $(LI added global option "Echo batch commands executed" to show commands during builds)
+    $(LI workaround /noopttls no longer added when building with LDC or dmd 2.076+)
+  ))
+  $(LI dmdserver:
+   $(UL
+    $(LI now enabled by default including semantic highlighting)
+    $(LI updated to dmd 2.092)
+    $(LI fix parameters not considered references to itself)
+    $(LI fix crash when invoking "Find All References")
+    $(LI fixed passing default versions to file not in any project)
+    $(LI now built with LDC)
+    $(LI improve preciseness for the GC)
+  ))
+  $(LI editor with dmdserver:
+   $(UL
+    $(LI implement "goto definition" by clicking identifier in tool tip)
+    $(LI add navigation bar)
+    $(LI fixed "Find in Solution" no longer working in VS 2019 16.6)
+  ))
+  $(LI mago debugger
+   $(UL
+    $(LI can now evaluate class/struct methods/fields __debugOverview, __debugExpanded, __debugTextView
+      to customize display in the debugger)
+    $(LI experimental: can now display ranges similar to arrays)
+    $(LI some performance improvements by caching some data while the debuggee is stopped)
+  ))
+  $(LI installer:
+   $(UL
+    $(LI full installer now bundled with dmd 2.092.1 and LDC 1.22.0)
+  ))
+ )
+
 $(H2 2020-03-23 Version 0.52.0)
  $(UL
   $(LI editor:

--- a/doc/visuald.ddoc
+++ b/doc/visuald.ddoc
@@ -1,6 +1,6 @@
-VERSION = 0.52.0
-DMD_VERSION = 2.091.0
-LDC_VERSION = 1.20.1
+VERSION = 1.0.0
+DMD_VERSION = 2.092.1
+LDC_VERSION = 1.22.0
 ROOT_DIR = https://www.dlang.org/
 ROOT = https://www.dlang.org
 BODYCLASS = visuald

--- a/nsis/visuald.nsi
+++ b/nsis/visuald.nsi
@@ -87,6 +87,9 @@
 !ifndef CONFIG
   !define CONFIG  "Release"
 !endif
+!ifndef CONFIG_DMDSERVER
+  !define CONFIG_DMDSERVER  "Release"
+!endif
 
   ;Name and file
   Name "${LONG_APPNAME}"
@@ -259,7 +262,7 @@ Section "Visual Studio package" SecPackage
 !endif
 
 !ifdef DMDSERVER
-  ${File} "..\bin\${CONFIG}\x64\" dmdserver.exe
+  ${File} "..\bin\${CONFIG_DMDSERVER}\x64\" dmdserver.exe
 !endif
 
 !ifdef VDEXTENSIONS

--- a/visuald/propertypage.d
+++ b/visuald/propertypage.d
@@ -3116,7 +3116,7 @@ struct MagoOptions
 		removeLeadingHexZeroes = (keyMago.GetDWORD("removeLeadingHexZeroes", 0) != 0);
 		recombineTuples        = (keyMago.GetDWORD("recombineTuples", 1) != 0);
 		callDebuggerFunctions  = (keyMago.GetDWORD("callDebuggerFunctions", 1) != 0);
-		callDebuggerRanges     = (keyMago.GetDWORD("callDebuggerRanges", 1) != 0);
+		callDebuggerRanges     = (keyMago.GetDWORD("callDebuggerRanges", 0) != 0);
 		callDebuggerUseMagoGC  = (keyMago.GetDWORD("callDebuggerUseMagoGC", 1) != 0);
 		showDArrayLengthInType = (keyMago.GetDWORD("showDArrayLengthInType", 0) != 0);
 		maxArrayElements  =  keyMago.GetDWORD("maxArrayElements", 1000);


### PR DESCRIPTION
- mago: change default to evaluate ranges to "off"
- update docs
- build Visuald.dll with dmd again (LDC 1.22 fails)