### PR TITLE
Add support for Visual Studio 2022 17.3 and 17.4

### DIFF
--- a/msbuild/dbuild/dbuild.csproj
+++ b/msbuild/dbuild/dbuild.csproj
@@ -159,6 +159,50 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TargetVer>17.2</TargetVer>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-v17_3|AnyCPU'">
+    <OutputPath>bin\Release-v17_3\</OutputPath>
+    <DefineConstants>TRACE;TOOLS_V17</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetVer>17.3</TargetVer>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-v17_3|AnyCPU'">
+    <OutputPath>bin\Debug-v17_3\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;TOOLS_V17</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>false</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetVer>17.3</TargetVer>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-v17_4|AnyCPU'">
+    <OutputPath>bin\Release-v17_4\</OutputPath>
+    <DefineConstants>TRACE;TOOLS_V17</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetVer>17.4</TargetVer>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-v17_4|AnyCPU'">
+    <OutputPath>bin\Debug-v17_4\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;TOOLS_V17</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>false</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TargetVer>17.4</TargetVer>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -202,7 +246,7 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkVersion Condition=" '$(TargetVer)' == '12.0' or '$(TargetVer)' == '14.0' ">v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkVersion Condition=" '$(TargetVer)' == '16.0' or '$(TargetVer)' == '16.1' ">v4.7.2</TargetFrameworkVersion>
-    <TargetFrameworkVersion Condition=" '$(TargetVer)' == '17.0' or '$(TargetVer)' == '17.1' or '$(TargetVer)' == '17.2' ">v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetVer)' == '17.0' or '$(TargetVer)' == '17.1' or '$(TargetVer)' == '17.2' or '$(TargetVer)' == '17.3' or '$(TargetVer)' == '17.4' ">v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
@@ -433,7 +477,7 @@
     </Reference>
   </ItemGroup>
   <!-- VS2022 -->
-  <ItemGroup Condition="'$(TargetVer)' == '17.0' or '$(TargetVer)' == '17.1' or '$(TargetVer)' == '17.2'">
+  <ItemGroup Condition="'$(TargetVer)' == '17.0' or '$(TargetVer)' == '17.1' or '$(TargetVer)' == '17.2' or '$(TargetVer)' == '17.3' or '$(TargetVer)' == '17.4'">
     <Reference Include="Microsoft.Build">
       <HintPath>assemblies\v17\Microsoft.Build.dll</HintPath>
     </Reference>
@@ -467,6 +511,16 @@
     </Reference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetVer)' == '17.2'">
+    <Reference Include="Microsoft.Build.CPPTasks.Common">
+      <HintPath>assemblies\v17_2\Microsoft.Build.CPPTasks.Common.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetVer)' == '17.3'">
+    <Reference Include="Microsoft.Build.CPPTasks.Common">
+      <HintPath>assemblies\v17_2\Microsoft.Build.CPPTasks.Common.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetVer)' == '17.4'">
     <Reference Include="Microsoft.Build.CPPTasks.Common">
       <HintPath>assemblies\v17_2\Microsoft.Build.CPPTasks.Common.dll</HintPath>
     </Reference>

--- a/msbuild/dcompile_defaults.props
+++ b/msbuild/dcompile_defaults.props
@@ -49,7 +49,9 @@
     <DBuildVersion Condition="$(MSBuildVersion_Major) == 16 and $(MSBuildVersion_Minor) != 0">16.1</DBuildVersion>
     <DBuildVersion Condition="$(MSBuildVersion_Major) == 17 and $(MSBuildVersion_Minor) == 0">17.0</DBuildVersion>
     <DBuildVersion Condition="$(MSBuildVersion_Major) == 17 and $(MSBuildVersion_Minor) == 1">17.1</DBuildVersion>
-    <DBuildVersion Condition="$(MSBuildVersion_Major) == 17 and $(MSBuildVersion_Minor) &gt; 1">17.2</DBuildVersion>
+    <DBuildVersion Condition="$(MSBuildVersion_Major) == 17 and $(MSBuildVersion_Minor) == 2">17.2</DBuildVersion>
+    <DBuildVersion Condition="$(MSBuildVersion_Major) == 17 and $(MSBuildVersion_Minor) == 3">17.3</DBuildVersion>
+    <DBuildVersion Condition="$(MSBuildVersion_Major) == 17 and $(MSBuildVersion_Minor) &gt; 3">17.4</DBuildVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DBuildVersion)' == ''">

--- a/nsis/visuald.nsi
+++ b/nsis/visuald.nsi
@@ -332,6 +332,8 @@ Section "Visual Studio package" SecPackage
   ${File} ..\msbuild\dbuild\obj\release-v17\ dbuild.17.0.dll
   ${File} ..\msbuild\dbuild\obj\release-v17_1\ dbuild.17.1.dll
   ${File} ..\msbuild\dbuild\obj\release-v17_2\ dbuild.17.2.dll
+  ${File} ..\msbuild\dbuild\obj\release-v17_3\ dbuild.17.3.dll
+  ${File} ..\msbuild\dbuild\obj\release-v17_4\ dbuild.17.4.dll
 !endif
   WriteRegStr HKLM "Software\${APPNAME}" "msbuild" $INSTDIR\msbuild
 !endif


### PR DESCRIPTION
Can't build D projects on VS 17.3 (latest Visual Studio 2022). 17.4 is the preview version and probably has the same problem.